### PR TITLE
fix: update all repository URLs from template to Airbolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This eliminates the traditional bottleneck where backend teams must manually wri
 
 ```bash
 # Clone the repository
-git clone https://github.com/mkwatson/ai-fastify-template.git
+git clone https://github.com/Airbolt-AI/airbolt.git
 cd ai-fastify-template
 
 # Setup development environment (includes GitLeaks security scanner)
@@ -434,8 +434,8 @@ _Always edit AGENTS.md for shared guidelines. Tool-specific files should remain 
 
 - 📖 [Documentation](docs/)
 - 🦀 [Rust Patterns Analysis](docs/RUST_PATTERNS_ANALYSIS.md) - How we achieve Rust-like safety in TypeScript
-- 🐛 [Issue Tracker](https://github.com/mkwatson/ai-fastify-template/issues)
-- 💬 [Discussions](https://github.com/mkwatson/ai-fastify-template/discussions)
+- 🐛 [Issue Tracker](https://github.com/Airbolt-AI/airbolt/issues)
+- 💬 [Discussions](https://github.com/Airbolt-AI/airbolt/discussions)
 
 ## Contributing
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -94,7 +94,7 @@ git --version     # >= 2.0.0
 1. **Clone and install**
 
    ```bash
-   git clone https://github.com/mkwatson/ai-fastify-template.git
+   git clone https://github.com/Airbolt-AI/airbolt.git
    cd ai-fastify-template
    pnpm install
    ```

--- a/package.json
+++ b/package.json
@@ -73,13 +73,13 @@
     "email": "mark@example.com"
   },
   "license": "MIT",
-  "homepage": "https://github.com/mkwatson/ai-fastify-template#readme",
+  "homepage": "https://github.com/Airbolt-AI/airbolt#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mkwatson/ai-fastify-template.git"
+    "url": "https://github.com/Airbolt-AI/airbolt.git"
   },
   "bugs": {
-    "url": "https://github.com/mkwatson/ai-fastify-template/issues"
+    "url": "https://github.com/Airbolt-AI/airbolt/issues"
   },
   "packageManager": "pnpm@10.8.0",
   "volta": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,12 +39,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mkwatson/ai-fastify-template.git",
+    "url": "https://github.com/Airbolt-AI/airbolt.git",
     "directory": "packages/sdk"
   },
-  "homepage": "https://github.com/mkwatson/ai-fastify-template#readme",
+  "homepage": "https://github.com/Airbolt-AI/airbolt#readme",
   "bugs": {
-    "url": "https://github.com/mkwatson/ai-fastify-template/issues"
+    "url": "https://github.com/Airbolt-AI/airbolt/issues"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary
- Update all references from mkwatson/ai-fastify-template to Airbolt-AI/airbolt
- Ensures project correctly references its own repository

## Changes
- package.json: Updated repository URL, homepage, and bugs URL
- README.md: Updated clone instructions and issue tracker/discussions links  
- docs/DEVELOPMENT.md: Updated clone instructions
- packages/sdk/package.json: Updated all repository URLs

## Verification
Ran grep to confirm no remaining references to the template repository.

🤖 Generated with Claude Code