### PR TITLE
feat(react-sdk): enhance useChat hook with Fern-based client features (MAR-121)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,15 @@ pnpm ci:simulate       # Runs build first (like CI does), then full validation
 - Pre-push hook uses `ci:simulate` to catch errors before they reach CI
 - This prevents the disconnect between local and CI validation
 
+**⚠️ SDK Generation Gotcha:**
+
+```bash
+# ALWAYS run after OpenAPI/Fern changes
+pnpm ci:simulate       # Regenerates SDK + full validation (matches CI exactly)
+```
+
+CI runs `pnpm generate` first, potentially causing fresh-generation TypeScript errors that don't appear locally with cached files.
+
 ## 🚨 **Test Configuration Management**
 
 **CRITICAL: We maintain two Vitest configurations for workspace vs mutation testing:**

--- a/packages/react-sdk/src/hooks/useChat.ts
+++ b/packages/react-sdk/src/hooks/useChat.ts
@@ -1,5 +1,10 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { chat } from '@airbolt/sdk';
+import {
+  chat,
+  clearAuthToken,
+  hasValidToken,
+  getTokenInfo,
+} from '@airbolt/sdk';
 import type { UseChatOptions, UseChatReturn, Message } from '../types/index.js';
 
 /**
@@ -8,12 +13,22 @@ import type { UseChatOptions, UseChatReturn, Message } from '../types/index.js';
  * @example
  * ```tsx
  * function ChatComponent() {
- *   const { messages, input, setInput, send, isLoading } = useChat({
+ *   const {
+ *     messages,
+ *     input,
+ *     setInput,
+ *     send,
+ *     isLoading,
+ *     clearToken,
+ *     hasValidToken,
+ *     getTokenInfo
+ *   } = useChat({
  *     system: 'You are a helpful assistant'
  *   });
  *
  *   return (
  *     <div>
+ *       <div>Auth Status: {hasValidToken() ? 'Authenticated' : 'Not authenticated'}</div>
  *       {messages.map((m, i) => (
  *         <div key={i}>
  *           <b>{m.role}:</b> {m.content}
@@ -26,6 +41,9 @@ import type { UseChatOptions, UseChatReturn, Message } from '../types/index.js';
  *       />
  *       <button onClick={send} disabled={isLoading}>
  *         Send
+ *       </button>
+ *       <button onClick={clearToken}>
+ *         Logout
  *       </button>
  *     </div>
  *   );
@@ -124,6 +142,19 @@ export function useChat(options?: UseChatOptions): UseChatReturn {
     abortControllerRef.current?.abort();
   }, []);
 
+  // Token management functions using the baseURL from options
+  const clearToken = useCallback(() => {
+    clearAuthToken(options?.baseURL);
+  }, [options?.baseURL]);
+
+  const checkValidToken = useCallback(() => {
+    return hasValidToken(options?.baseURL);
+  }, [options?.baseURL]);
+
+  const getTokenInfoCallback = useCallback(() => {
+    return getTokenInfo(options?.baseURL);
+  }, [options?.baseURL]);
+
   return {
     messages,
     input,
@@ -132,5 +163,8 @@ export function useChat(options?: UseChatOptions): UseChatReturn {
     error,
     send,
     clear,
+    clearToken,
+    hasValidToken: checkValidToken,
+    getTokenInfo: getTokenInfoCallback,
   };
 }

--- a/packages/react-sdk/src/types/index.ts
+++ b/packages/react-sdk/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { Message } from '@airbolt/sdk';
+import type { Message, TokenInfo } from '@airbolt/sdk';
 
 /**
  * Options for the useChat hook
@@ -50,9 +50,21 @@ export interface UseChatReturn {
    * Clear all messages and reset the conversation
    */
   clear: () => void;
+  /**
+   * Clear the authentication token (useful for logout)
+   */
+  clearToken: () => void;
+  /**
+   * Check if there's a valid authentication token
+   */
+  hasValidToken: () => boolean;
+  /**
+   * Get token information for debugging
+   */
+  getTokenInfo: () => TokenInfo;
 }
 
 /**
- * Re-export Message type from SDK for convenience
+ * Re-export types from SDK for convenience
  */
-export type { Message } from '@airbolt/sdk';
+export type { Message, TokenInfo } from '@airbolt/sdk';

--- a/packages/react-sdk/test/components/ChatWidget.test.tsx
+++ b/packages/react-sdk/test/components/ChatWidget.test.tsx
@@ -36,6 +36,9 @@ describe('ChatWidget XSS Protection', () => {
     clear: vi.fn(),
     isLoading: false,
     error: null,
+    clearToken: vi.fn(),
+    hasValidToken: vi.fn(() => true),
+    getTokenInfo: vi.fn(() => ({ hasToken: true })),
   };
 
   beforeEach(() => {

--- a/packages/react-sdk/test/hooks/useChat.test.ts
+++ b/packages/react-sdk/test/hooks/useChat.test.ts
@@ -3,17 +3,39 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { useChat } from '../../src/hooks/useChat.js';
 import type { Message } from '@airbolt/sdk';
 
-// Mock the SDK chat function
+// Mock the SDK functions
 vi.mock('@airbolt/sdk', () => ({
   chat: vi.fn(),
+  clearAuthToken: vi.fn(),
+  hasValidToken: vi.fn(() => true),
+  getTokenInfo: vi.fn(() => ({
+    hasToken: true,
+    expiresAt: new Date(Date.now() + 3600000),
+    tokenType: 'Bearer',
+  })),
 }));
 
-import { chat } from '@airbolt/sdk';
+import {
+  chat,
+  clearAuthToken,
+  hasValidToken,
+  getTokenInfo,
+} from '@airbolt/sdk';
 const mockChat = vi.mocked(chat);
+const mockClearAuthToken = vi.mocked(clearAuthToken);
+const mockHasValidToken = vi.mocked(hasValidToken);
+const mockGetTokenInfo = vi.mocked(getTokenInfo);
 
 describe('useChat', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset mocks to default states
+    mockHasValidToken.mockReturnValue(true);
+    mockGetTokenInfo.mockReturnValue({
+      hasToken: true,
+      expiresAt: new Date(Date.now() + 3600000),
+      tokenType: 'Bearer',
+    });
   });
 
   afterEach(() => {
@@ -315,5 +337,206 @@ describe('useChat', () => {
       [{ role: 'user', content: 'Hello world' }],
       {}
     );
+  });
+
+  describe('Authentication token management', () => {
+    it('should expose token management functions', () => {
+      const { result } = renderHook(() => useChat());
+
+      expect(typeof result.current.clearToken).toBe('function');
+      expect(typeof result.current.hasValidToken).toBe('function');
+      expect(typeof result.current.getTokenInfo).toBe('function');
+    });
+
+    it('should call clearAuthToken with correct baseURL', () => {
+      const customBaseURL = 'https://api.example.com';
+      const { result } = renderHook(() => useChat({ baseURL: customBaseURL }));
+
+      act(() => {
+        result.current.clearToken();
+      });
+
+      expect(mockClearAuthToken).toHaveBeenCalledWith(customBaseURL);
+    });
+
+    it('should call clearAuthToken with undefined when no baseURL provided', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.clearToken();
+      });
+
+      expect(mockClearAuthToken).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should call hasValidToken with correct baseURL', () => {
+      const customBaseURL = 'https://api.example.com';
+      const { result } = renderHook(() => useChat({ baseURL: customBaseURL }));
+
+      const isValid = result.current.hasValidToken();
+
+      expect(mockHasValidToken).toHaveBeenCalledWith(customBaseURL);
+      expect(isValid).toBe(true);
+    });
+
+    it('should call getTokenInfo with correct baseURL', () => {
+      const customBaseURL = 'https://api.example.com';
+      const expectedTokenInfo = {
+        hasToken: true,
+        expiresAt: new Date(),
+        tokenType: 'Bearer',
+      };
+      mockGetTokenInfo.mockReturnValue(expectedTokenInfo);
+
+      const { result } = renderHook(() => useChat({ baseURL: customBaseURL }));
+
+      const tokenInfo = result.current.getTokenInfo();
+
+      expect(mockGetTokenInfo).toHaveBeenCalledWith(customBaseURL);
+      expect(tokenInfo).toEqual(expectedTokenInfo);
+    });
+
+    it('should update token functions when baseURL changes', () => {
+      const { result, rerender } = renderHook(
+        ({ baseURL }) => useChat({ baseURL }),
+        { initialProps: { baseURL: 'https://api1.example.com' } }
+      );
+
+      // Clear mocks to isolate baseURL change behavior
+      vi.clearAllMocks();
+
+      rerender({ baseURL: 'https://api2.example.com' });
+
+      act(() => {
+        result.current.clearToken();
+      });
+
+      expect(mockClearAuthToken).toHaveBeenCalledWith(
+        'https://api2.example.com'
+      );
+    });
+
+    it('should handle token operations after component unmount', () => {
+      const { result, unmount } = renderHook(() => useChat());
+
+      // Get references to functions before unmount
+      const clearToken = result.current.clearToken;
+      const hasValidToken = result.current.hasValidToken;
+      const getTokenInfo = result.current.getTokenInfo;
+
+      unmount();
+
+      // Functions should still work (they're bound to client, not component)
+      expect(() => clearToken()).not.toThrow();
+      expect(() => hasValidToken()).not.toThrow();
+      expect(() => getTokenInfo()).not.toThrow();
+    });
+
+    it('should handle different authentication states', () => {
+      // Test authenticated state
+      mockHasValidToken.mockReturnValue(true);
+      mockGetTokenInfo.mockReturnValue({
+        hasToken: true,
+        expiresAt: new Date(Date.now() + 3600000),
+        tokenType: 'Bearer',
+      });
+
+      const { result: authenticatedResult } = renderHook(() => useChat());
+
+      expect(authenticatedResult.current.hasValidToken()).toBe(true);
+      expect(authenticatedResult.current.getTokenInfo().hasToken).toBe(true);
+
+      // Test unauthenticated state
+      mockHasValidToken.mockReturnValue(false);
+      mockGetTokenInfo.mockReturnValue({
+        hasToken: false,
+      });
+
+      const { result: unauthenticatedResult } = renderHook(() => useChat());
+
+      expect(unauthenticatedResult.current.hasValidToken()).toBe(false);
+      expect(unauthenticatedResult.current.getTokenInfo().hasToken).toBe(false);
+    });
+
+    it('should support complete authentication lifecycle', async () => {
+      const { result } = renderHook(() =>
+        useChat({
+          baseURL: 'https://api.example.com',
+        })
+      );
+
+      // Initially authenticated
+      expect(result.current.hasValidToken()).toBe(true);
+
+      // Use chat functionality while authenticated
+      mockChat.mockResolvedValueOnce('Hello! I can help you.');
+      act(() => result.current.setInput('Hi'));
+      await act(async () => await result.current.send());
+
+      expect(result.current.messages).toHaveLength(2);
+      expect(result.current.messages[0]).toEqual({
+        role: 'user',
+        content: 'Hi',
+      });
+
+      // Logout
+      act(() => result.current.clearToken());
+      expect(mockClearAuthToken).toHaveBeenCalledWith(
+        'https://api.example.com'
+      );
+
+      // Verify token state after logout
+      mockHasValidToken.mockReturnValue(false);
+      expect(result.current.hasValidToken()).toBe(false);
+    });
+
+    it('should handle token function errors gracefully', () => {
+      // Mock token functions to throw errors
+      mockClearAuthToken.mockImplementation(() => {
+        throw new Error('Clear token failed');
+      });
+      mockHasValidToken.mockImplementation(() => {
+        throw new Error('Check token failed');
+      });
+      mockGetTokenInfo.mockImplementation(() => {
+        throw new Error('Get token info failed');
+      });
+
+      const { result } = renderHook(() => useChat());
+
+      // Functions should propagate errors (caller should handle them)
+      expect(() => result.current.clearToken()).toThrow('Clear token failed');
+      expect(() => result.current.hasValidToken()).toThrow(
+        'Check token failed'
+      );
+      expect(() => result.current.getTokenInfo()).toThrow(
+        'Get token info failed'
+      );
+    });
+
+    it('should maintain function reference stability with useCallback', () => {
+      const { result, rerender } = renderHook(
+        ({ baseURL }) => useChat({ baseURL }),
+        { initialProps: { baseURL: 'https://api.example.com' } }
+      );
+
+      const clearToken1 = result.current.clearToken;
+      const hasValidToken1 = result.current.hasValidToken;
+      const getTokenInfo1 = result.current.getTokenInfo;
+
+      // Rerender with same props - functions should be stable
+      rerender({ baseURL: 'https://api.example.com' });
+
+      expect(result.current.clearToken).toBe(clearToken1);
+      expect(result.current.hasValidToken).toBe(hasValidToken1);
+      expect(result.current.getTokenInfo).toBe(getTokenInfo1);
+
+      // Rerender with different baseURL - functions should update
+      rerender({ baseURL: 'https://api2.example.com' });
+
+      expect(result.current.clearToken).not.toBe(clearToken1);
+      expect(result.current.hasValidToken).not.toBe(hasValidToken1);
+      expect(result.current.getTokenInfo).not.toBe(getTokenInfo1);
+    });
   });
 });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,20 +2,20 @@
   "name": "@airbolt/sdk",
   "version": "1.0.0",
   "description": "Type-safe TypeScript SDK for the Airbolt API with automatic token management",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
     },
     "./browser": {
       "types": "./generated/browser/index.d.ts",
       "import": "./generated/browser/index.js"
     },
     "./node": {
-      "types": "./generated/node/index.d.ts", 
+      "types": "./generated/node/index.d.ts",
       "import": "./generated/node/index.js"
     }
   },

--- a/packages/sdk/src/api/client-utils.ts
+++ b/packages/sdk/src/api/client-utils.ts
@@ -1,0 +1,83 @@
+import { AirboltClient } from '../core/fern-client.js';
+
+/**
+ * Token information for debugging
+ */
+export interface TokenInfo {
+  hasToken: boolean;
+  expiresAt?: Date;
+  tokenType?: string;
+}
+
+/**
+ * Global client instances cache to reuse clients for same baseURL
+ */
+const clientCache = new Map<string, AirboltClient>();
+
+/**
+ * Get or create a client instance for the given baseURL
+ */
+function getClientInstance(baseURL?: string): AirboltClient {
+  const url = baseURL || 'http://localhost:3000';
+
+  if (!clientCache.has(url)) {
+    clientCache.set(url, new AirboltClient({ baseURL: url }));
+  }
+
+  return clientCache.get(url)!;
+}
+
+/**
+ * Clear the authentication token for a specific baseURL
+ *
+ * @param baseURL The base URL for the API (defaults to localhost:3000)
+ *
+ * @example
+ * ```typescript
+ * // Clear token for default URL
+ * clearAuthToken();
+ *
+ * // Clear token for specific URL
+ * clearAuthToken('https://api.airbolt.dev');
+ * ```
+ */
+export function clearAuthToken(baseURL?: string): void {
+  const client = getClientInstance(baseURL);
+  client.clearToken();
+}
+
+/**
+ * Check if there's a valid authentication token for a specific baseURL
+ *
+ * @param baseURL The base URL for the API (defaults to localhost:3000)
+ * @returns True if a valid token exists
+ *
+ * @example
+ * ```typescript
+ * if (hasValidToken()) {
+ *   console.log('User is authenticated');
+ * }
+ * ```
+ */
+export function hasValidToken(baseURL?: string): boolean {
+  const client = getClientInstance(baseURL);
+  return client.hasValidToken();
+}
+
+/**
+ * Get token information for debugging purposes
+ *
+ * @param baseURL The base URL for the API (defaults to localhost:3000)
+ * @returns Token information object
+ *
+ * @example
+ * ```typescript
+ * const info = getTokenInfo();
+ * console.log('Has token:', info.hasToken);
+ * console.log('Expires at:', info.expiresAt);
+ * ```
+ */
+export function getTokenInfo(baseURL?: string): TokenInfo {
+  const client = getClientInstance(baseURL);
+  return client.getTokenInfo();
+}

--- a/packages/sdk/src/api/index.ts
+++ b/packages/sdk/src/api/index.ts
@@ -2,5 +2,9 @@
 export { chat } from './chat.js';
 export { createChatSession } from './session.js';
 
+// Client utility functions
+export { clearAuthToken, hasValidToken, getTokenInfo } from './client-utils.js';
+
 // Type exports
 export type { Message, ChatOptions, ChatSession } from './types.js';
+export type { TokenInfo } from './client-utils.js';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -20,8 +20,19 @@ export * from './core/index.js';
 // export * from './generated/node/index.js';
 
 // Export API functions
-export { chat, createChatSession } from './api/index.js';
-export type { Message, ChatOptions, ChatSession } from './api/index.js';
+export {
+  chat,
+  createChatSession,
+  clearAuthToken,
+  hasValidToken,
+  getTokenInfo,
+} from './api/index.js';
+export type {
+  Message,
+  ChatOptions,
+  ChatSession,
+  TokenInfo,
+} from './api/index.js';
 
 // Default export for convenience
 export { AirboltClient as default } from './core/fern-client.js';


### PR DESCRIPTION
## Summary

Enhanced the React `useChat` hook to expose Fern-based client token management and debugging features while maintaining the clean API layer architecture. This provides React developers with direct access to authentication features without compromising the stable public interface.

## Key Changes

### SDK Enhancement
- **New API functions**: Added `clearAuthToken()`, `hasValidToken()`, `getTokenInfo()` to SDK exports
- **Client utilities**: Created `src/api/client-utils.ts` with global client instance caching
- **Type exports**: Added `TokenInfo` type for debugging token state
- **Package config**: Fixed build output paths to match actual TypeScript compilation structure

### React Hook Enhancement  
- **Extended interface**: Added `clearToken`, `hasValidToken`, `getTokenInfo` methods to `useChat` return
- **Preserved functionality**: All existing features (optimistic updates, error handling, cleanup) unchanged
- **Enhanced documentation**: Updated JSDoc examples showing new authentication features
- **Performance optimized**: Used `useCallback` for all new functions to prevent unnecessary re-renders

### Architecture Benefits
- **✅ API stability**: Maintained the stable `chat()` function interface
- **✅ Fern integration**: Leveraged Fern-generated client through clean wrapper layer
- **✅ Client reuse**: Implemented global client cache for better performance
- **✅ Future-proof**: Direct access to client features enables advanced use cases

## Testing Results

- **✅ All tests pass**: 25/25 React SDK tests successful
- **✅ TypeScript compilation**: Zero errors across all packages  
- **✅ Linting**: Code follows project standards
- **✅ Backward compatibility**: Existing code continues to work unchanged
- **✅ Quality gates**: Full validation pipeline passed

## API Examples

### Enhanced useChat Hook
```typescript
const { 
  messages, input, send, isLoading, // ← Existing features preserved
  clearToken, hasValidToken, getTokenInfo // ← New authentication features  
} = useChat({ 
  system: 'You are a helpful assistant',
  baseURL: 'https://api.airbolt.dev' 
});

// Check authentication status
if (hasValidToken()) {
  console.log('User authenticated');
}

// Debug token information
const tokenInfo = getTokenInfo();
console.log('Token expires:', tokenInfo.expiresAt);

// Logout functionality
const handleLogout = () => {
  clearToken();
  // Token cleared for this baseURL
};
```

### SDK API Functions
```typescript
import { clearAuthToken, hasValidToken, getTokenInfo } from '@airbolt/sdk';

// Clear tokens for specific environment
clearAuthToken('https://api.airbolt.dev');

// Check authentication across environments  
const isAuth = hasValidToken('https://api.airbolt.dev');

// Debug token state
const info = getTokenInfo('https://api.airbolt.dev');
```

## Implementation Approach

Followed the **correct architecture** we established:

```
React useChat → API Layer → AirboltClient (Fern wrapper) → AirboltAPIClient (Fern)
```

**Benefits**:
- **API Control**: We own the interface, Fern changes don't break users
- **Type Safety**: Simple, stable types shield complexity  
- **Future-Proofing**: Fern updates don't affect React consumers
- **Clean DX**: Simple function calls vs complex client management

## Breaking Changes

None - this is a purely additive enhancement that maintains full backward compatibility.

## Documentation Updates

- ✅ Updated `useChat` JSDoc with comprehensive examples showing new features
- ✅ Added extensive documentation for new SDK API functions  
- ✅ Type interfaces fully documented with examples
- ✅ No outdated documentation remains

## Deployment Considerations

- Generated Fern client files are not committed (generated at build time)
- Run `pnpm generate` to regenerate Fern clients if needed
- All existing React applications continue to work without changes
- New features are opt-in via destructuring assignment

Closes MAR-121

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>