### PR TITLE
feat: configure Render deployment with one-click deploy button (MAR-85)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,5 @@ OPENAI_API_KEY=sk-your-openai-api-key-here
 # RATE_LIMIT_MAX=60
 # RATE_LIMIT_TIME_WINDOW=60000
 
-# Optional: Trust proxy headers (only enable if behind a trusted proxy/load balancer)
-# TRUST_PROXY=false
+# Optional: Trust proxy headers (enable for cloud deployments like Koyeb)
+# TRUST_PROXY=true

--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ Built for **fully autonomous AI development workflows** where AI agents generate
 
 This eliminates the traditional bottleneck where backend teams must manually write and maintain client SDKs, documentation, and coordinate API changes with frontend teams.
 
+## 🚀 Deploy to Render
+
+Deploy your own instance of Airbolt in seconds:
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Airbolt-AI/airbolt)
+
+### Setup (< 60 seconds)
+
+1. **Click the button above**
+2. **Enter your OpenAI API key** when prompted
+3. **Click "Create Web Service"**
+
+That's it! Your API will be live at `https://your-service-name.onrender.com` 🎉
+
+> **Note**: Free tier services spin down after 15 minutes of inactivity. First request after sleep takes ~1 minute.
+
 ## Quick Start
 
 ### Prerequisites

--- a/apps/backend-api/src/server.ts
+++ b/apps/backend-api/src/server.ts
@@ -23,8 +23,8 @@ const start = async (): Promise<void> => {
   try {
     const port: number = getPort();
 
-    await server.listen({ port });
-    server.log.info(`Server listening on port ${String(port)}`);
+    await server.listen({ port, host: '0.0.0.0' });
+    server.log.info(`Server listening on http://0.0.0.0:${String(port)}`);
   } catch (err) {
     server.log.error(err);
     throw new Error('Failed to start server');

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,27 @@
+services:
+  - type: web
+    name: airbolt
+    runtime: node
+    plan: free
+    buildCommand: npm install -g pnpm && pnpm install && pnpm build
+    startCommand: node apps/backend-api/dist/server.js
+    healthCheckPath: /
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: PORT
+        value: 10000
+      - key: OPENAI_API_KEY
+        sync: false # Prompts user to enter value during deployment
+      - key: JWT_SECRET
+        generateValue: true # Render generates a secure random value
+      - key: ALLOWED_ORIGIN
+        value: '*' # Users can update this later for production
+      - key: TRUST_PROXY
+        value: 'true'
+      - key: LOG_LEVEL
+        value: info
+      - key: RATE_LIMIT_MAX
+        value: '60'
+      - key: RATE_LIMIT_TIME_WINDOW
+        value: '60000'


### PR DESCRIPTION
## Summary

This PR switches our one-click deployment from Koyeb to Render based on UX testing that revealed Koyeb's deployment flow was too complex for our target audience (beginner frontend developers).

## Changes

- ✨ Add `render.yaml` configuration for one-click deployment
- 🔧 Update server to bind to `0.0.0.0` for container compatibility  
- 📝 Replace Koyeb with Render deploy button in README
- 🎯 Simplify deployment instructions to true 3-step process
- 🔐 Configure environment variables with inline secret prompts

## Why Render Over Koyeb

After testing Koyeb deployment, we discovered several UX issues:

1. **Confusing pricing display** - Shows "$0.0036/hr" without clear free tier indication
2. **Complex secret management** - Users must leave deployment flow to create secrets
3. **Port configuration** - Defaults to 8000 instead of our 3000
4. **Too many steps** - The "60 seconds to AI chat" promise was unrealistic

Render provides:
- ✅ Clear "Free" tier indication
- ✅ Inline secret entry during deployment
- ✅ Auto-generated JWT secrets
- ✅ Unique URLs per deployment (airbolt-XXXX.onrender.com)
- ✅ Actually achievable 60-second setup

## Testing

- [x] Lint and type-check pass
- [x] All 549 tests pass
- [x] Security audit clean
- [x] Build commands verified locally
- [ ] Live deployment test pending

## Deployment Notes

- Free tier services spin down after 15 minutes of inactivity
- First request after sleep takes ~1 minute
- 750 hours/month included in free tier

Closes MAR-85

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>