### PR TITLE
fix: update Render deployment configuration to bypass Docker requirement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,5 @@ OPENAI_API_KEY=sk-your-openai-api-key-here
 # RATE_LIMIT_MAX=60
 # RATE_LIMIT_TIME_WINDOW=60000
 
-# Optional: Trust proxy headers (enable for cloud deployments like Koyeb)
+# Optional: Trust proxy headers (enable for cloud deployments like Render)
 # TRUST_PROXY=true

--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,5 @@ OPENAI_API_KEY=sk-your-openai-api-key-here
 # RATE_LIMIT_MAX=60
 # RATE_LIMIT_TIME_WINDOW=60000
 
-# Optional: Trust proxy headers (only enable if behind a trusted proxy/load balancer)
-# TRUST_PROXY=false
+# Optional: Trust proxy headers (enable for cloud deployments like Koyeb)
+# TRUST_PROXY=true

--- a/README.md
+++ b/README.md
@@ -89,10 +89,23 @@ Deploy your own instance of Airbolt in seconds:
 ### Setup (< 60 seconds)
 
 1. **Click the button above**
-2. **Enter your OpenAI API key** when prompted
-3. **Click "Create Web Service"**
+2. **Enter a unique name** (e.g., `airbolt-backend-123`)
+3. **Enter your OpenAI API key** when prompted
+4. **Click "Apply"**
 
-That's it! Your API will be live at `https://your-service-name.onrender.com` 🎉
+That's it! Your API will be live in ~3 minutes 🎉
+
+**Find your URL**: After deployment completes, click on your service name in the [Render Dashboard](https://dashboard.render.com). Your URL will be shown at the top (e.g., `https://airbolt-backend-123.onrender.com`)
+
+### Using Your Deployed API
+
+```javascript
+import { AirboltAPI } from '@airbolt/sdk';
+
+const client = new AirboltAPI({
+  baseURL: 'https://your-service.onrender.com',
+});
+```
 
 > **Note**: Free tier services spin down after 15 minutes of inactivity. First request after sleep takes ~1 minute.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ Built for **fully autonomous AI development workflows** where AI agents generate
 
 This eliminates the traditional bottleneck where backend teams must manually write and maintain client SDKs, documentation, and coordinate API changes with frontend teams.
 
+## 🚀 Deploy to Render
+
+Deploy your own instance of Airbolt in seconds:
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Airbolt-AI/airbolt)
+
+### Setup (< 60 seconds)
+
+1. **Click the button above**
+2. **Enter your OpenAI API key** when prompted
+3. **Click "Create Web Service"**
+
+That's it! Your API will be live at `https://your-service-name.onrender.com` 🎉
+
+> **Note**: Free tier services spin down after 15 minutes of inactivity. First request after sleep takes ~1 minute.
+
 ## Quick Start
 
 ### Prerequisites

--- a/apps/backend-api/src/server.ts
+++ b/apps/backend-api/src/server.ts
@@ -23,8 +23,8 @@ const start = async (): Promise<void> => {
   try {
     const port: number = getPort();
 
-    await server.listen({ port });
-    server.log.info(`Server listening on port ${String(port)}`);
+    await server.listen({ port, host: '0.0.0.0' });
+    server.log.info(`Server listening on http://0.0.0.0:${String(port)}`);
   } catch (err) {
     server.log.error(err);
     throw new Error('Failed to start server');

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: airbolt
     runtime: node
     plan: free
-    buildCommand: npm install -g pnpm && pnpm install && pnpm build
+    buildCommand: npm install -g pnpm && pnpm install --frozen-lockfile && pnpm exec nx run backend-api:build
     startCommand: node apps/backend-api/dist/server.js
     healthCheckPath: /
     envVars:

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,27 @@
+services:
+  - type: web
+    name: airbolt
+    runtime: node
+    plan: free
+    buildCommand: npm install -g pnpm && pnpm install && pnpm build
+    startCommand: node apps/backend-api/dist/server.js
+    healthCheckPath: /
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: PORT
+        value: 10000
+      - key: OPENAI_API_KEY
+        sync: false # Prompts user to enter value during deployment
+      - key: JWT_SECRET
+        generateValue: true # Render generates a secure random value
+      - key: ALLOWED_ORIGIN
+        value: '*' # Users can update this later for production
+      - key: TRUST_PROXY
+        value: 'true'
+      - key: LOG_LEVEL
+        value: info
+      - key: RATE_LIMIT_MAX
+        value: '60'
+      - key: RATE_LIMIT_TIME_WINDOW
+        value: '60000'


### PR DESCRIPTION
## Summary

This PR fixes the Render deployment failure by updating the build command to bypass the Docker-requiring prebuild step.

## Problem

The deployment was failing with:
```
❌ Docker is not installed or not in PATH
```

This happened because:
1. `pnpm build` triggers a `prebuild` script
2. The `prebuild` script runs `pnpm generate` (SDK generation via Fern)
3. Fern requires Docker, which isn't available in Render's build environment

## Solution

- Changed build command from `pnpm build` to `pnpm exec nx run backend-api:build`
- This bypasses the prebuild hook and builds only what we need
- The SDK is already generated and committed, so we don't need Docker during deployment

## Additional Changes

- Updated `.env.example` to reference Render instead of Koyeb
- Improved deployment instructions with URL discovery details
- Added SDK usage example showing how to connect to deployed API

## Testing

- [x] Verified build command works locally
- [x] Confirmed SDK files are already committed
- [x] All validation checks pass
- [ ] Deployment on Render (needs testing after merge)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>