### PR TITLE
feat(cors): add wildcard origin support for Render deployment

### DIFF
--- a/apps/backend-api/src/plugins/cors.ts
+++ b/apps/backend-api/src/plugins/cors.ts
@@ -18,9 +18,10 @@ export default fp(
           return;
         }
 
-        // Check exact match against allowed origins
+        // Check if wildcard or exact match against allowed origins
+        const allowedOrigins = fastify.config?.ALLOWED_ORIGIN ?? [];
         const isAllowed =
-          fastify.config?.ALLOWED_ORIGIN.includes(origin) ?? false;
+          allowedOrigins.includes('*') || allowedOrigins.includes(origin);
         callback(
           isAllowed ? null : new Error('Not allowed by CORS'),
           isAllowed

--- a/apps/backend-api/src/plugins/env.ts
+++ b/apps/backend-api/src/plugins/env.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto';
 import fp from 'fastify-plugin';
 import { z } from 'zod';
 
-const EnvSchema = z
+export const EnvSchema = z
   .object({
     NODE_ENV: z
       .enum(['development', 'production', 'test'], {
@@ -71,6 +71,10 @@ const EnvSchema = z
       .refine(
         origins =>
           origins.every(origin => {
+            // Allow wildcard for all origins
+            if (origin === '*') {
+              return true;
+            }
             try {
               // Validate each origin is a valid URL
               const url = new URL(origin);
@@ -79,7 +83,7 @@ const EnvSchema = z
               return false;
             }
           }),
-        'ALLOWED_ORIGIN must contain valid HTTP(S) URLs (comma-separated if multiple)'
+        'ALLOWED_ORIGIN must contain valid HTTP(S) URLs or * for all origins'
       ),
 
     SYSTEM_PROMPT: z

--- a/render.yaml
+++ b/render.yaml
@@ -16,7 +16,7 @@ services:
       - key: JWT_SECRET
         generateValue: true # Render generates a secure random value
       - key: ALLOWED_ORIGIN
-        value: '*' # Users can update this later for production
+        value: '*' # Allow all origins (update for production)
       - key: TRUST_PROXY
         value: 'true'
       - key: LOG_LEVEL


### PR DESCRIPTION
## Summary
- Export EnvSchema from env.ts to enable proper testing
- Add support for wildcard '*' in ALLOWED_ORIGIN validation
- Update CORS plugin to handle wildcard origins correctly
- Fix testing anti-pattern by importing schema instead of duplicating
- Configure render.yaml with wildcard origin for easy deployment

## Why This Change?
During Render deployment testing, we discovered that the environment validation was rejecting wildcard '*' for ALLOWED_ORIGIN. This prevented easy deployment for frontend developers who need to test from various origins.

## What Changed?
1. **Environment Validation**: Added support for '*' wildcard in ALLOWED_ORIGIN
2. **CORS Plugin**: Updated to handle wildcard by checking `allowedOrigins.includes('*')`
3. **Testing**: Fixed anti-pattern where schema was duplicated in tests - now imports from source
4. **Deployment**: render.yaml configured with `ALLOWED_ORIGIN: '*'` for immediate use

## Test plan
- [x] All existing tests pass
- [x] Added 3 new tests for wildcard functionality
- [x] Manual validation of wildcard behavior
- [x] Deployment configuration tested

🤖 Generated with Claude Code