### PR TITLE
fix: remove .github/README.md that was overriding root README display

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,1 +1,0 @@
-# Fixed phantom check issue


### PR DESCRIPTION
Removes the .github/README.md file that was created during testing and was causing GitHub to show 'Fixed phantom check issue' instead of the full README at the repository root.

GitHub prioritizes .github/README.md over root README.md for repository display.