### PR TITLE
fix: remove SDK build step from docs workflow (MAR-138)

### DIFF
--- a/.github/workflows/sdk-docs.yml
+++ b/.github/workflows/sdk-docs.yml
@@ -43,11 +43,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build SDKs
-        run: |
-          cd packages/sdk && pnpm build
-          cd ../react-sdk && pnpm build
-
       - name: Generate documentation
         run: |
           cd packages/sdk && pnpm docs

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ test-results/
 
 # Fern-generated SDK code (prebuild generation)
 packages/sdk/generated/
+
+# Generated documentation (GitHub Actions builds these)
+docs/api/


### PR DESCRIPTION
## Summary

This PR fixes the failing GitHub Actions workflow for SDK documentation deployment. The workflow was failing because it tried to build the SDK packages, which triggered prebuild hooks that attempt to generate Fern client files that don't exist in the repository.

### What Changed
- 🔧 Removed the "Build SDKs" step from the workflow
- 📝 Added  to  for generated documentation
- ✨ TypeDoc only needs TypeScript source files, not built artifacts

### Why This Fix Works
The workflow was failing with:
```
Cannot find module '../../generated/index.js'
```

This happened because:
1. `pnpm build` triggers the prebuild hook
2. The prebuild runs `sdk-generate.sh` which tries to generate Fern SDK files
3. These generated files aren't (and shouldn't be) in the repository
4. TypeDoc doesn't need compiled JavaScript anyway - it reads TypeScript source directly

### Best Practices Applied
- ✅ Generated files excluded from version control (like `dist/`, `node_modules/`)
- ✅ Clean separation of concerns - docs generation doesn't depend on SDK compilation
- ✅ Minimal solution - removed unnecessary steps rather than adding workarounds

## Testing

The workflow will now:
1. Install dependencies
2. Generate documentation directly from TypeScript source
3. Deploy to GitHub Pages

No SDK build is needed for documentation generation.

## Breaking Changes

None - this only affects the CI/CD pipeline.

Closes MAR-138