### PR TITLE
fix(cors): allow wildcard origins in production for SDK deployment model

### DIFF
--- a/apps/backend-api/README.md
+++ b/apps/backend-api/README.md
@@ -48,7 +48,7 @@ All environment variables are validated using Zod schemas for type safety and ru
 | `HOST`                   | Server host                                    | `localhost`             | Any valid hostname                                 |
 | `LOG_LEVEL`              | Logging verbosity                              | `info`                  | `fatal`, `error`, `warn`, `info`, `debug`, `trace` |
 | `JWT_SECRET`             | Secret for JWT signing (auto-generated in dev) | Auto-generated          | Min 32 characters                                  |
-| `ALLOWED_ORIGIN`         | CORS allowed origins (comma-separated)         | `http://localhost:5173` | Valid HTTP(S) URLs                                 |
+| `ALLOWED_ORIGIN`         | CORS allowed origins (comma-separated)         | `*` (dev), test origins | Valid HTTP(S) URLs or `*` for all origins          |
 | `SYSTEM_PROMPT`          | Custom AI system prompt                        | `""` (empty)            | Any string                                         |
 | `RATE_LIMIT_MAX`         | Max requests per window                        | `100`                   | Positive integer                                   |
 | `RATE_LIMIT_TIME_WINDOW` | Rate limit window (ms)                         | `60000` (1 minute)      | Positive integer (milliseconds)                    |
@@ -63,15 +63,22 @@ All environment variables are validated using Zod schemas for type safety and ru
   - All sensitive environment variables (API keys, secrets) are automatically redacted in logs
   - Never commit `.env` files to version control
 
-### Multiple Origins Example
+### CORS Configuration
+
+The API supports flexible CORS configuration for different deployment scenarios:
 
 ```bash
+# Allow all origins (SDK deployment model)
+ALLOWED_ORIGIN=*
+
 # Single origin
 ALLOWED_ORIGIN=https://example.com
 
 # Multiple origins (comma-separated)
 ALLOWED_ORIGIN=https://example.com,https://app.example.com,http://localhost:3000
 ```
+
+**Note**: The wildcard (`*`) is allowed in all environments to support the SDK deployment model where users deploy their own API instances. Security is handled through JWT tokens and rate limiting.
 
 ### Rate Limiting Examples
 

--- a/apps/backend-api/test/plugins/env.direct.test.ts
+++ b/apps/backend-api/test/plugins/env.direct.test.ts
@@ -337,6 +337,7 @@ describe('Environment Plugin Direct Tests', () => {
       const app = Fastify({ logger: false });
       process.env = {
         ...originalEnv,
+        NODE_ENV: 'test',
         OPENAI_API_KEY: validApiKey,
         ALLOWED_ORIGIN: invalidOrigin,
       };
@@ -579,13 +580,13 @@ describe('Environment Plugin Direct Tests', () => {
       // Find the warning log about auto-generation
       // Pino uses numeric levels: 30 = warn
       const warningLog = logs.find(
-        log => log.msg && log.msg.includes('JWT_SECRET not provided')
+        log => log.msg && log.msg.includes('JWT_SECRET auto-generated')
       );
 
       expect(warningLog).toBeDefined();
       expect(warningLog.JWT_SECRET).toBe('[REDACTED - auto-generated]');
-      expect(warningLog.msg).toContain('development use only');
-      expect(warningLog.msg).toContain('stable tokens across restarts');
+      expect(warningLog.msg).toContain('auto-generated for development');
+      expect(warningLog.msg).toContain('stable tokens');
     } finally {
       process.env = originalEnv;
       await app.close();

--- a/render.yaml
+++ b/render.yaml
@@ -16,7 +16,7 @@ services:
       - key: JWT_SECRET
         generateValue: true # Render generates a secure random value
       - key: ALLOWED_ORIGIN
-        value: '*' # Allow all origins (update for production)
+        value: '*' # Allow all origins for SDK deployment model
       - key: TRUST_PROXY
         value: 'true'
       - key: LOG_LEVEL


### PR DESCRIPTION
## Summary

- Remove restriction on wildcard (*) CORS origins in production environments
- Update documentation to explain the SDK deployment model rationale
- Maintain security through JWT tokens and rate limiting instead of origin restrictions

## Context

The original CORS validation prevented wildcard origins in production, which conflicts with the SDK deployment model where users deploy their own API instances. Since each user deploys their own backend, they need to support requests from any domain where their web app might be hosted.

## Changes

1. **Environment validation** (`env.ts`):
   - Removed the check that blocked wildcard origins in production
   - Added comment explaining security is handled via JWT + rate limiting

2. **Documentation** (`README.md`):
   - Updated ALLOWED_ORIGIN description to clarify wildcard is allowed
   - Added CORS Configuration section explaining deployment scenarios
   - Noted that security is maintained through authentication/rate limiting

3. **Deployment config** (`render.yaml`):
   - Updated comment to reflect SDK deployment model

4. **Tests**:
   - Updated cors-security tests to expect wildcard to work in production
   - Fixed env.direct test to set NODE_ENV properly
   - Updated JWT warning message expectations

## Testing

All tests pass:
- ✅ CORS security tests validate wildcard works in all environments
- ✅ Environment validation tests confirm proper behavior
- ✅ Pre-push hooks passed (lint, type-check, test config validation)

## Security Considerations

While allowing wildcard origins might seem less secure, in the context of the SDK deployment model it's appropriate because:
- Each user deploys their own isolated API instance
- Security is enforced through JWT authentication
- Rate limiting prevents abuse
- The API doesn't store sensitive cross-user data

🤖 Generated with [Claude Code](https://claude.ai/code)