### PR TITLE
chore: release v0.3.1

### DIFF
--- a/.changeset/fix-trailing-slash-url.md
+++ b/.changeset/fix-trailing-slash-url.md
@@ -1,9 +1,0 @@
----
-'@airbolt/sdk': patch
----
-
-Fix URL construction when baseURL has trailing slashes
-
-- Prevents double slashes (e.g., `//api/tokens`) when baseURL ends with `/`
-- Handles multiple trailing slashes correctly
-- Fixes 404 errors on deployed instances where users provide URLs with trailing slashes

--- a/packages/react-sdk/CHANGELOG.md
+++ b/packages/react-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.1
+
+### Patch Changes
+
+- Updated dependencies [[`1401611`](https://github.com/Airbolt-AI/airbolt/commit/14016111ed12d7e1c961c7e56f2ac5785e50278d)]:
+  - @airbolt/sdk@0.3.1
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airbolt/react-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "React hooks and utilities for the Airbolt API with built-in state management",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.1
+
+### Patch Changes
+
+- [#48](https://github.com/Airbolt-AI/airbolt/pull/48) [`1401611`](https://github.com/Airbolt-AI/airbolt/commit/14016111ed12d7e1c961c7e56f2ac5785e50278d) Thanks [@mkwatson](https://github.com/mkwatson)! - Fix URL construction when baseURL has trailing slashes
+  - Prevents double slashes (e.g., `//api/tokens`) when baseURL ends with `/`
+  - Handles multiple trailing slashes correctly
+  - Fixes 404 errors on deployed instances where users provide URLs with trailing slashes
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airbolt/sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Type-safe TypeScript SDK for the Airbolt API with automatic token management",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Release v0.3.1

This PR releases SDK version 0.3.1 with the following changes:

### @airbolt/sdk@0.3.1
- Fix URL construction when baseURL has trailing slashes (#48)
  - Prevents double slashes (e.g., `//api/tokens`) when baseURL ends with `/`
  - Handles multiple trailing slashes correctly
  - Fixes 404 errors on deployed instances where users provide URLs with trailing slashes

### @airbolt/react-sdk@0.3.1
- Updated peer dependency to @airbolt/sdk@0.3.1

## Release Process
Once this PR is merged, the GitHub Actions workflow will automatically:
1. Build and test all packages
2. Publish both SDKs to npm
3. Create GitHub releases

🤖 Generated with [Claude Code](https://claude.ai/code)