### PR TITLE
fix: add manual workflow dispatch to Beta Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Beta Release
 on:
   push:
     tags: ['v0.*'] # Only beta versions
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.3.1)'
+        required: true
+        type: string
 
 jobs:
   release:
@@ -14,13 +20,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - uses: ./.github/actions/setup-project
 
       # Validate this is a beta release
       - name: Validate Beta Release
         run: |
-          if [[ ! "${GITHUB_REF#refs/tags/v}" =~ ^0\. ]]; then
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          if [[ ! "${TAG#v}" =~ ^0\. ]]; then
             echo "❌ This workflow only handles beta releases (0.x.x)"
             echo "For stable releases, use the stable release workflow"
             exit 1


### PR DESCRIPTION
## Problem
The Beta Release workflow is not triggering on tag pushes. The v0.3.1 tag was pushed multiple times but the workflow never triggered, even though:
- The tag pattern matches (`v0.*` should match `v0.3.1`)
- The previous v0.3.0 tag worked on July 15th
- Actions are enabled and other workflows run fine

This appears to be related to GitHub Actions security changes or limitations on forked repositories.

## Solution
Add `workflow_dispatch` with a tag input to allow manual triggering of releases when automatic tag triggers fail.

## Changes
- Added `workflow_dispatch` event with `tag` input parameter
- Updated checkout step to use the provided tag or fall back to the pushed tag
- Updated validation to work with both trigger methods

## Usage
After this PR is merged, you can manually trigger releases from the Actions tab:
1. Go to Actions → Beta Release
2. Click "Run workflow"
3. Enter the tag (e.g., `v0.3.1`)
4. Click "Run workflow"

This provides a fallback when tag push triggers don't work while we investigate the root cause.