### PR TITLE
feat(docs): add prominent private beta signup CTA to homepage (MAR-149)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,6 +18,9 @@
         --text: #e2e8f0;
         --text-muted: #94a3b8;
         --border: #334155;
+        --beta-gradient-start: var(--primary);
+        --beta-gradient-end: var(--secondary);
+        --beta-border-radius: 16px;
       }
 
       * {
@@ -293,9 +296,9 @@
 
       /* Beta CTA Section */
       .beta-cta {
-        background: linear-gradient(135deg, var(--primary), var(--secondary));
+        background: linear-gradient(135deg, var(--beta-gradient-start), var(--beta-gradient-end));
         margin: 1.5rem 0 3rem 0;
-        border-radius: 16px;
+        border-radius: var(--beta-border-radius);
         padding: 3rem 2rem;
         text-align: center;
         position: relative;
@@ -311,6 +314,7 @@
         bottom: 0;
         background: rgba(255, 255, 255, 0.1);
         backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
         z-index: 1;
       }
 
@@ -349,6 +353,7 @@
         box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
         margin-bottom: 1rem;
         border: 2px solid transparent;
+        will-change: transform, box-shadow;
       }
 
       .beta-cta-button:hover {
@@ -359,7 +364,7 @@
 
       .beta-cta-secondary {
         font-size: 0.95rem;
-        color: rgba(255, 255, 255, 0.8);
+        color: rgba(255, 255, 255, 0.9);
         margin-top: 1rem;
       }
 
@@ -409,6 +414,13 @@
       .token-import {
         color: #8be9fd;
       }
+
+      /* Print styles */
+      @media print {
+        .beta-cta {
+          display: none; /* Hide promotional content when printing docs */
+        }
+      }
     </style>
   </head>
   <body>
@@ -441,14 +453,18 @@
       </section>
 
       <section class="container">
-        <div class="beta-cta">
+        <div class="beta-cta" data-test-variant="zero-backend">
           <div class="beta-cta-content">
             <h2>🚀 Try Hosted Airbolt Beta</h2>
             <p>
               Skip the deployment! Get AI chat in your app with zero backend setup. 
               No servers, no configuration, no hassle.
             </p>
-            <a href="https://forms.gle/2yWKszvJBZReN6kf7" class="beta-cta-button" target="_blank" rel="noopener noreferrer">
+            <a href="https://forms.gle/2yWKszvJBZReN6kf7" 
+               class="beta-cta-button" 
+               target="_blank" 
+               rel="noopener noreferrer"
+               aria-label="Join Airbolt private beta - opens in new tab">
               Join Private Beta
             </a>
             <div class="beta-cta-secondary">

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,7 +84,7 @@
 
       /* Hero Section */
       .hero {
-        padding: 5rem 0;
+        padding: 5rem 0 2rem 0;
         text-align: center;
       }
 
@@ -294,7 +294,7 @@
       /* Beta CTA Section */
       .beta-cta {
         background: linear-gradient(135deg, var(--primary), var(--secondary));
-        margin: 3rem 0;
+        margin: 1.5rem 0 3rem 0;
         border-radius: 16px;
         padding: 3rem 2rem;
         text-align: center;

--- a/docs/index.html
+++ b/docs/index.html
@@ -291,6 +291,108 @@
         text-decoration: underline;
       }
 
+      /* Beta CTA Section */
+      .beta-cta {
+        background: linear-gradient(135deg, var(--primary), var(--secondary));
+        margin: 3rem 0;
+        border-radius: 16px;
+        padding: 3rem 2rem;
+        text-align: center;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .beta-cta::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(255, 255, 255, 0.1);
+        backdrop-filter: blur(10px);
+        z-index: 1;
+      }
+
+      .beta-cta-content {
+        position: relative;
+        z-index: 2;
+      }
+
+      .beta-cta h2 {
+        font-size: 2.5rem;
+        font-weight: 800;
+        color: white;
+        margin-bottom: 1rem;
+        text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      }
+
+      .beta-cta p {
+        font-size: 1.25rem;
+        color: rgba(255, 255, 255, 0.95);
+        margin-bottom: 2rem;
+        max-width: 600px;
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      .beta-cta-button {
+        display: inline-block;
+        background: rgba(255, 255, 255, 0.95);
+        color: var(--primary);
+        padding: 1rem 2.5rem;
+        border-radius: 12px;
+        text-decoration: none;
+        font-weight: 700;
+        font-size: 1.1rem;
+        transition: all 0.3s ease;
+        box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+        margin-bottom: 1rem;
+        border: 2px solid transparent;
+      }
+
+      .beta-cta-button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+        background: white;
+      }
+
+      .beta-cta-secondary {
+        font-size: 0.95rem;
+        color: rgba(255, 255, 255, 0.8);
+        margin-top: 1rem;
+      }
+
+      .beta-cta-secondary a {
+        color: rgba(255, 255, 255, 0.9);
+        text-decoration: underline;
+      }
+
+      .beta-cta-secondary a:hover {
+        color: white;
+      }
+
+      /* Mobile responsiveness for beta CTA */
+      @media (max-width: 768px) {
+        .beta-cta {
+          margin: 2rem 0;
+          padding: 2rem 1rem;
+        }
+
+        .beta-cta h2 {
+          font-size: 2rem;
+        }
+
+        .beta-cta p {
+          font-size: 1.1rem;
+        }
+
+        .beta-cta-button {
+          padding: 0.875rem 2rem;
+          font-size: 1rem;
+        }
+      }
+
       /* Code highlighting */
       .token-keyword {
         color: #ff79c6;
@@ -336,6 +438,24 @@
           Build secure AI-powered applications with our TypeScript and React
           SDKs. Production-ready, type-safe, and designed for developers.
         </p>
+      </section>
+
+      <section class="container">
+        <div class="beta-cta">
+          <div class="beta-cta-content">
+            <h2>🚀 Try Hosted Airbolt Beta</h2>
+            <p>
+              Skip the deployment! Get AI chat in your app with zero backend setup. 
+              No servers, no configuration, no hassle.
+            </p>
+            <a href="https://forms.gle/2yWKszvJBZReN6kf7" class="beta-cta-button" target="_blank" rel="noopener noreferrer">
+              Join Private Beta
+            </a>
+            <div class="beta-cta-secondary">
+              Or <a href="#sdks">deploy your own version</a> below ↓
+            </div>
+          </div>
+        </div>
       </section>
 
       <section id="sdks" class="container">


### PR DESCRIPTION
## Summary

Adds a highly visible call-to-action section to the documentation homepage that drives traffic to the hosted Airbolt private beta signup. This creates a direct conversion path from docs visitors (especially those coming from airbolt.ai) to beta signups.

## Changes

- Added prominent beta CTA section with gradient background after hero section
- Implemented mobile-responsive design with proper breakpoints
- Used compelling copy highlighting "zero backend setup" value proposition
- Added secondary path for users who prefer self-hosting
- Adjusted spacing between sections for better visual flow

## Screenshots

The beta CTA features:
- Beautiful gradient background (blue to green)
- High contrast white button for visibility
- Clear value proposition messaging
- Mobile-responsive design

## Testing

- [x] Verified button links to correct Google Forms URL
- [x] Tested responsive design at various breakpoints
- [x] Confirmed proper link attributes for security
- [x] Validated HTML/CSS passes all quality checks
- [x] Tested locally with Playwright browser automation

## Success Criteria Met

From MAR-149:
- ✅ Prominent "Try Hosted Beta" CTA section added
- ✅ Links to private beta signup page (https://forms.gle/2yWKszvJBZReN6kf7)
- ✅ Visually prominent and above the fold
- ✅ Clear value proposition copy
- ✅ Mobile-responsive design
- ⚠️ A/B testing (requires JS/analytics - out of scope)
- ⚠️ Click tracking (requires analytics - out of scope)

## Implementation Details

- Pure HTML/CSS implementation (no JavaScript)
- Uses existing design system variables for consistency
- Glassmorphism effect with graceful degradation
- Total addition: ~120 lines of well-structured code

## Deployment Considerations

- Static documentation change only
- No build or runtime impact
- Will be live once GitHub Pages rebuilds

Closes MAR-149

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>