### PR TITLE
fix(react-sdk): display special characters correctly in ChatWidget (MAR-155)

### DIFF
--- a/packages/react-sdk/src/components/ChatWidget.tsx
+++ b/packages/react-sdk/src/components/ChatWidget.tsx
@@ -9,21 +9,6 @@ import {
   defaultThemes,
 } from './ChatWidget.styles.js';
 
-/**
- * Escapes HTML entities to prevent XSS attacks
- * Converts potentially dangerous characters to safe HTML entities
- */
-function escapeHtml(text: string): string {
-  const htmlEntities: Record<string, string> = {
-    '<': '&lt;',
-    '>': '&gt;',
-    '&': '&amp;',
-    '"': '&quot;',
-    "'": '&#39;',
-  };
-  return text.replace(/[<>&"']/g, char => htmlEntities[char] ?? char);
-}
-
 export type { MinimalTheme } from './ChatWidget.styles.js';
 
 export interface ChatWidgetProps {
@@ -217,7 +202,7 @@ export function ChatWidget({
             role="article"
             aria-label={`${message.role} message`}
           >
-            {escapeHtml(message.content)}
+            {message.content}
           </div>
         ))}
 


### PR DESCRIPTION
## Summary

- Fixed special characters (apostrophes, quotes, etc.) displaying as HTML entities in ChatWidget
- Removed unnecessary HTML escaping that was causing `It's` to display as `It&#39;s`
- Maintained XSS protection through React's built-in text rendering safety

## Problem

The ChatWidget was displaying escaped HTML entities instead of rendering special characters properly. This affected both user and bot messages, making the chat experience appear broken when using common characters like apostrophes.

## Solution

Removed the manual `escapeHtml` function and rely on React's built-in XSS protection for text content. React automatically prevents script injection when rendering text as children (not using `dangerouslySetInnerHTML`).

## Changes

- Removed `escapeHtml` function from ChatWidget.tsx (-14 lines)
- Changed message rendering from `{escapeHtml(message.content)}` to `{message.content}`
- Updated XSS tests to expect unescaped text while verifying scripts don't execute
- Added comprehensive tests for special character rendering

## Testing

- ✅ All existing XSS tests pass (verified malicious scripts cannot execute)
- ✅ New tests added for apostrophes, quotes, and mixed special characters
- ✅ Both user and assistant messages tested
- ✅ All react-sdk tests passing (53 tests)

## Security

XSS protection is maintained through React's default behavior:
- Text content rendered as children is automatically safe
- No use of `dangerouslySetInnerHTML`
- Malicious HTML tags are rendered as plain text, not executed

Closes MAR-155

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>