### PR TITLE
feat(rate-limiting): implement token-based rate limiting and usage tracking (MAR-164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ That's it! Your app now has secure AI chat that can't be abused by random users.
 4. Backend verifies the JWT signature on every request
 5. Invalid/expired tokens are rejected with 401 Unauthorized
 
-**Abuse prevention built-in** - Even if someone gets a token, they can only use it for 15 minutes. Rate limiting (100 requests/minute) prevents runaway usage.
+**Abuse prevention built-in** - Even if someone gets a token, they can only use it for 15 minutes. Token-based rate limiting prevents runaway usage:
+
+- **Token limits**: 1,000 tokens per hour per user (configurable)
+- **Request limits**: 10 requests per minute per user (configurable)
+- **Real-time usage tracking**: Know exactly how much each user consumes
+- **Automatic 429 responses**: When limits are exceeded, clients get clear rate limit errors
 
 **Pre-built backend** - We provide the backend, you just deploy it. One-click to Render or any Node.js hosting platform. No custom server code to write or maintain.
 
@@ -132,7 +137,7 @@ The roadmap is driven by feedback from developers using Airbolt.
 import { useChat } from '@airbolt/react-sdk';
 
 function CustomChat() {
-  const { messages, input, setInput, send, isLoading } = useChat({
+  const { messages, input, setInput, send, isLoading, usage } = useChat({
     baseURL: 'https://my-ai-backend.onrender.com',
     system:
       'You are a coding assistant. Help users debug their code and suggest improvements.',
@@ -140,6 +145,14 @@ function CustomChat() {
 
   return (
     <div className="chat-container">
+      {/* Display usage info when available */}
+      {usage && usage.tokens && (
+        <div className="usage-info">
+          Tokens: {usage.tokens.used}/{usage.tokens.limit}
+          (resets {new Date(usage.tokens.resetAt).toLocaleTimeString()})
+        </div>
+      )}
+
       <div className="messages">
         {messages.map((msg, i) => (
           <div key={i} className={`message ${msg.role}`}>

--- a/apps/backend-api/openapi.json
+++ b/apps/backend-api/openapi.json
@@ -150,6 +150,42 @@
                         "total_tokens": {
                           "type": "number",
                           "description": "Total tokens used in the request"
+                        },
+                        "tokens": {
+                          "type": "object",
+                          "properties": {
+                            "used": {
+                              "type": "number"
+                            },
+                            "remaining": {
+                              "type": "number"
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "resetAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        },
+                        "requests": {
+                          "type": "object",
+                          "properties": {
+                            "used": {
+                              "type": "number"
+                            },
+                            "remaining": {
+                              "type": "number"
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "resetAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
                         }
                       }
                     }
@@ -218,6 +254,47 @@
                     },
                     "statusCode": {
                       "type": "number"
+                    },
+                    "usage": {
+                      "type": "object",
+                      "properties": {
+                        "tokens": {
+                          "type": "object",
+                          "properties": {
+                            "used": {
+                              "type": "number"
+                            },
+                            "remaining": {
+                              "type": "number"
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "resetAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        },
+                        "requests": {
+                          "type": "object",
+                          "properties": {
+                            "used": {
+                              "type": "number"
+                            },
+                            "remaining": {
+                              "type": "number"
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "resetAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/apps/backend-api/package.json
+++ b/apps/backend-api/package.json
@@ -65,6 +65,7 @@
     "fastify-plugin": "^5.0.0",
     "fastify-sse-v2": "^4.2.1",
     "openai": "^5.8.2",
+    "rate-limiter-flexible": "^7.1.1",
     "zod": "^3.25.67"
   },
   "devDependencies": {

--- a/apps/backend-api/src/app.ts
+++ b/apps/backend-api/src/app.ts
@@ -150,6 +150,10 @@ const app: FastifyPluginAsync<AppOptions> = async (
             RATE_LIMIT_TIME_WINDOW: 60000,
             TRUST_PROXY: false,
             JWT_SECRET: 'openapi-generation-only-jwt-secret-placeholder',
+            TOKEN_LIMIT_MAX: 100000,
+            TOKEN_LIMIT_TIME_WINDOW: 3600000,
+            REQUEST_LIMIT_MAX: 100,
+            REQUEST_LIMIT_TIME_WINDOW: 3600000,
           };
           fastify.decorate('config', mockConfig);
         },
@@ -163,6 +167,9 @@ const app: FastifyPluginAsync<AppOptions> = async (
 
   // Register rate limit plugin after env (it depends on RATE_LIMIT_* from env)
   await fastify.register(rateLimitPlugin);
+
+  // Register user rate limit plugin after env (for token/request tracking)
+  await fastify.register(import('./plugins/user-rate-limit.js'));
 
   // Register SSE plugin for streaming support
   await fastify.register(fastifySse);

--- a/apps/backend-api/src/plugins/env.ts
+++ b/apps/backend-api/src/plugins/env.ts
@@ -124,6 +124,43 @@ export const EnvSchema = z
         invalid_type_error: 'TRUST_PROXY must be a boolean',
       })
       .default(false),
+
+    // Token-based rate limiting
+    TOKEN_LIMIT_MAX: z.coerce
+      .number({
+        invalid_type_error: 'TOKEN_LIMIT_MAX must be a number',
+      })
+      .int('TOKEN_LIMIT_MAX must be an integer')
+      .min(1000, 'TOKEN_LIMIT_MAX must be at least 1000')
+      .default(100000), // 100k tokens default
+
+    TOKEN_LIMIT_TIME_WINDOW: z.coerce
+      .number({
+        invalid_type_error: 'TOKEN_LIMIT_TIME_WINDOW must be a number',
+      })
+      .int('TOKEN_LIMIT_TIME_WINDOW must be an integer')
+      .min(60000, 'TOKEN_LIMIT_TIME_WINDOW must be at least 60000ms (1 minute)')
+      .default(3600000), // 1 hour default
+
+    // Request-based rate limiting for authenticated users
+    REQUEST_LIMIT_MAX: z.coerce
+      .number({
+        invalid_type_error: 'REQUEST_LIMIT_MAX must be a number',
+      })
+      .int('REQUEST_LIMIT_MAX must be an integer')
+      .min(1, 'REQUEST_LIMIT_MAX must be greater than 0')
+      .default(100), // 100 requests default
+
+    REQUEST_LIMIT_TIME_WINDOW: z.coerce
+      .number({
+        invalid_type_error: 'REQUEST_LIMIT_TIME_WINDOW must be a number',
+      })
+      .int('REQUEST_LIMIT_TIME_WINDOW must be an integer')
+      .min(
+        60000,
+        'REQUEST_LIMIT_TIME_WINDOW must be at least 60000ms (1 minute)'
+      )
+      .default(3600000), // 1 hour default
   })
   .transform(data => {
     // Auto-generate JWT_SECRET in non-production environments when not provided

--- a/apps/backend-api/src/plugins/user-rate-limit.ts
+++ b/apps/backend-api/src/plugins/user-rate-limit.ts
@@ -184,7 +184,9 @@ declare module 'fastify' {
     ) => Promise<void>;
     consumeTokens: (userId: string, tokens: number) => Promise<void>;
     getUserUsage: (userId: string) => Promise<UsageInfo>;
-    reserveTokens: (userId: string, tokens: number) => Promise<void>;
-    refundTokens: (userId: string, tokens: number) => Promise<void>;
+    userRateLimiters: {
+      requestLimiter: RateLimiterMemory;
+      tokenLimiter: RateLimiterMemory;
+    };
   }
 }

--- a/apps/backend-api/src/routes/api/chat.ts
+++ b/apps/backend-api/src/routes/api/chat.ts
@@ -51,8 +51,9 @@ async function verifyJWT(
   try {
     const token = auth.slice(7);
     const payload = request.server.jwt.verify(token);
-    request.jwt = payload as JWTPayload;
-    request.user = payload as JWTPayload;
+    const jwtPayload = payload as JWTPayload;
+    request.jwt = jwtPayload;
+    request.user = jwtPayload;
   } catch (error) {
     request.log.warn({ error }, 'JWT verification failed');
     throw request.server.httpErrors.unauthorized('Invalid or expired token');

--- a/apps/backend-api/src/services/ai-provider.ts
+++ b/apps/backend-api/src/services/ai-provider.ts
@@ -27,6 +27,22 @@ export const ChatResponseSchema = z.object({
   usage: z
     .object({
       total_tokens: z.number(),
+      tokens: z
+        .object({
+          used: z.number(),
+          remaining: z.number(),
+          limit: z.number(),
+          resetAt: z.string(),
+        })
+        .optional(),
+      requests: z
+        .object({
+          used: z.number(),
+          remaining: z.number(),
+          limit: z.number(),
+          resetAt: z.string(),
+        })
+        .optional(),
     })
     .optional(),
 });

--- a/apps/backend-api/src/services/ai-provider.ts
+++ b/apps/backend-api/src/services/ai-provider.ts
@@ -310,7 +310,10 @@ export class AIProviderService {
     systemPromptOverride?: string,
     providerOverride?: string,
     modelOverride?: string
-  ): Promise<AsyncIterable<string>> {
+  ): Promise<{
+    textStream: AsyncIterable<string>;
+    usage: Promise<{ totalTokens: number }>;
+  }> {
     const messagesWithSystem = this.injectSystemPrompt(
       messages,
       systemPromptOverride
@@ -368,21 +371,15 @@ export class AIProviderService {
       }));
 
       // Use Vercel AI SDK's streamText function
-      const stream = streamText({
+      const result = streamText({
         model: modelToUse,
         messages: formattedMessages,
         temperature: 0.7,
         maxTokens: 1000,
       });
 
-      // Convert the stream to an async iterable of strings
-      async function* stringStream(): AsyncIterable<string> {
-        for await (const part of stream.textStream) {
-          yield part;
-        }
-      }
-
-      return Promise.resolve(stringStream());
+      // Return the entire result object so we can access usage later
+      return Promise.resolve(result);
     } catch (error) {
       this.handleProviderError(error, providerForError);
     }

--- a/apps/backend-api/test/plugins/user-rate-limit.property.test.ts
+++ b/apps/backend-api/test/plugins/user-rate-limit.property.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fc from 'fast-check';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import userRateLimit from '../../src/plugins/user-rate-limit.js';
+import envPlugin from '../../src/plugins/env.js';
+import sensiblePlugin from '../../src/plugins/sensible.js';
+import { createTestEnv } from '@airbolt/test-utils';
+
+// Generate unique user IDs to avoid state pollution between tests
+let userCounter = 0;
+const getUniqueUserId = () => `test-user-${++userCounter}-${Date.now()}`;
+
+describe('User Rate Limiter Property Tests', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    createTestEnv({
+      TOKEN_LIMIT_MAX: '1000',
+      TOKEN_LIMIT_TIME_WINDOW: '3600000', // 1 hour
+      REQUEST_LIMIT_MAX: '10',
+      REQUEST_LIMIT_TIME_WINDOW: '60000', // 1 minute
+    });
+
+    app = Fastify({ logger: false });
+    await app.register(sensiblePlugin);
+    await app.register(envPlugin);
+    await app.register(userRateLimit);
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('Rate limiter behavior', () => {
+    it('consumes tokens even when exceeding limit but throws error', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.array(fc.integer({ min: 1, max: 200 }), {
+            minLength: 1,
+            maxLength: 20,
+          }),
+          async tokenRequests => {
+            const userId = getUniqueUserId();
+            let totalConsumed = 0;
+            const limit = 1000;
+
+            for (const tokens of tokenRequests) {
+              const wouldExceedLimit = totalConsumed + tokens > limit;
+
+              try {
+                await app.consumeTokens(userId, tokens);
+                totalConsumed += tokens;
+              } catch (error) {
+                // When request would exceed limit:
+                // - It still consumes the tokens
+                // - But throws an error
+                expect(wouldExceedLimit).toBe(true);
+                totalConsumed += tokens; // Tokens are consumed even on error!
+
+                // Verify tokens were consumed despite the error
+                const afterUsage = await app.getUserUsage(userId);
+                expect(afterUsage.tokens.used).toBe(totalConsumed);
+              }
+            }
+
+            // Verify final usage matches what we tracked
+            const usage = await app.getUserUsage(userId);
+            expect(usage.tokens.used).toBe(totalConsumed);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('consumes requests even when exceeding limit but throws error', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 20 }),
+          async requestCount => {
+            const userId = getUniqueUserId();
+            const limit = 10;
+            let actualRequests = 0;
+
+            // Create a fake request/reply for testing
+            const fakeRequest: any = {
+              user: { userId },
+              userRateLimiters: (app as any).userRateLimiters,
+            };
+            const fakeReply: any = {
+              code: vi.fn().mockReturnThis(),
+              send: vi.fn(),
+            };
+
+            for (let i = 0; i < requestCount; i++) {
+              const wouldExceedLimit = actualRequests + 1 > limit;
+
+              try {
+                await app.checkUserRateLimit(fakeRequest, fakeReply);
+                actualRequests++;
+              } catch (error) {
+                // Request is counted even when it fails
+                actualRequests++;
+                expect(wouldExceedLimit).toBe(true);
+              }
+            }
+
+            const usage = await app.getUserUsage(userId);
+            expect(usage.requests.used).toBe(actualRequests);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  // Token reservation and refund tests removed - simplified implementation
+  // Now we just consume tokens after knowing the actual usage
+
+  describe('Edge cases and boundary conditions', () => {
+    it('handles zero token consumption', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 0, max: 500 }),
+          async initialConsumption => {
+            const userId = getUniqueUserId();
+
+            if (initialConsumption > 0) {
+              await app.consumeTokens(userId, initialConsumption);
+            }
+
+            const before = await app.getUserUsage(userId);
+
+            // Consuming 0 should always succeed
+            await expect(app.consumeTokens(userId, 0)).resolves.not.toThrow();
+
+            const after = await app.getUserUsage(userId);
+            expect(after.tokens.used).toBe(before.tokens.used);
+          }
+        ),
+        { numRuns: 20 }
+      );
+    });
+
+    it('handles consumption around the limit boundary', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 800, max: 999 }),
+          fc.integer({ min: 1, max: 300 }),
+          async (initialConsumption, attemptAmount) => {
+            const userId = getUniqueUserId();
+
+            // Consume initial amount
+            await app.consumeTokens(userId, initialConsumption);
+
+            // const usage = await app.getUserUsage(userId);
+
+            // Try to consume more
+            const wouldExceedLimit = initialConsumption + attemptAmount > 1000;
+
+            try {
+              await app.consumeTokens(userId, attemptAmount);
+
+              // Should succeed if it doesn't exceed limit
+              expect(wouldExceedLimit).toBe(false);
+
+              const afterUsage = await app.getUserUsage(userId);
+              expect(afterUsage.tokens.used).toBe(
+                initialConsumption + attemptAmount
+              );
+            } catch (error) {
+              // Should fail if it would exceed limit
+              expect(wouldExceedLimit).toBe(true);
+
+              // BUT tokens are still consumed even on error!
+              const afterUsage = await app.getUserUsage(userId);
+              expect(afterUsage.tokens.used).toBe(
+                initialConsumption + attemptAmount
+              );
+              expect(afterUsage.tokens.used).toBeGreaterThan(1000);
+            }
+          }
+        ),
+        { numRuns: 20 }
+      );
+    });
+
+    it('allows consuming exactly the remaining tokens before limit', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 100, max: 900 }),
+          async initialConsumption => {
+            const userId = getUniqueUserId();
+
+            // Consume initial amount
+            await app.consumeTokens(userId, initialConsumption);
+
+            const usage = await app.getUserUsage(userId);
+            const remaining = 1000 - usage.tokens.used;
+
+            // Should be able to consume exactly the remaining
+            await expect(
+              app.consumeTokens(userId, remaining)
+            ).resolves.not.toThrow();
+
+            // Should now be at exactly the limit
+            const finalUsage = await app.getUserUsage(userId);
+            expect(finalUsage.tokens.used).toBe(1000);
+            expect(finalUsage.tokens.remaining).toBe(0);
+
+            // Next request should fail
+            await expect(app.consumeTokens(userId, 1)).rejects.toThrow(
+              /Token limit exceeded/
+            );
+          }
+        ),
+        { numRuns: 20 }
+      );
+    });
+
+    it('rate limiter behavior: requests fail when limit exceeded', async () => {
+      const userId = getUniqueUserId();
+
+      // Use up most of the limit
+      await app.consumeTokens(userId, 900);
+
+      // Try to use more than remaining - should fail
+      await expect(app.consumeTokens(userId, 200)).rejects.toThrow(
+        /Token limit exceeded/
+      );
+
+      // Verify the state after limit exceeded
+      const usage = await app.getUserUsage(userId);
+      expect(usage.tokens.used).toBeGreaterThan(1000); // rate-limiter-flexible behavior
+      expect(usage.tokens.remaining).toBe(0);
+    });
+  });
+});

--- a/apps/backend-api/test/plugins/user-rate-limit.simple.test.ts
+++ b/apps/backend-api/test/plugins/user-rate-limit.simple.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import userRateLimit from '../../src/plugins/user-rate-limit.js';
+import envPlugin from '../../src/plugins/env.js';
+import sensiblePlugin from '../../src/plugins/sensible.js';
+import { createTestEnv } from '@airbolt/test-utils';
+
+describe('Rate Limiter Behavior Test', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    createTestEnv({
+      TOKEN_LIMIT_MAX: '1000', // Test with actual limit
+      TOKEN_LIMIT_TIME_WINDOW: '3600000',
+      REQUEST_LIMIT_MAX: '10', // Test with actual limit
+      REQUEST_LIMIT_TIME_WINDOW: '60000',
+    });
+
+    app = Fastify({ logger: false });
+    await app.register(sensiblePlugin);
+    await app.register(envPlugin);
+    await app.register(userRateLimit);
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('shows exact rate limiter behavior for tokens', async () => {
+    const userId = 'test-user-1';
+
+    console.log('\n=== Token Rate Limiter Test ===');
+
+    // Test 1: Can we consume exactly up to the limit?
+    console.log('\nTest 1: Consuming exactly 1000 tokens');
+    await app.consumeTokens(userId, 1000);
+    let usage = await app.getUserUsage(userId);
+    console.log(
+      `Result: used=${usage.tokens.used}, remaining=${usage.tokens.remaining}`
+    );
+
+    // Try one more
+    try {
+      await app.consumeTokens(userId, 1);
+      console.log('SUCCESS: Consumed 1 more token after reaching limit');
+      usage = await app.getUserUsage(userId);
+      console.log(
+        `Result: used=${usage.tokens.used}, remaining=${usage.tokens.remaining}`
+      );
+    } catch (error) {
+      console.log(
+        'FAILED: Could not consume 1 more token after reaching limit'
+      );
+    }
+  });
+
+  it('shows behavior when approaching limit', async () => {
+    const userId = 'test-user-2';
+
+    console.log('\n=== Approaching Limit Test ===');
+
+    // Test 2: What happens when we go from below to above limit?
+    console.log('\nTest 2: Consuming 999 then 2 tokens');
+    await app.consumeTokens(userId, 999);
+    let usage = await app.getUserUsage(userId);
+    console.log(
+      `After 999: used=${usage.tokens.used}, remaining=${usage.tokens.remaining}`
+    );
+
+    try {
+      await app.consumeTokens(userId, 2);
+      console.log('SUCCESS: Consumed 2 more tokens (now at 1001)');
+      usage = await app.getUserUsage(userId);
+      console.log(
+        `Result: used=${usage.tokens.used}, remaining=${usage.tokens.remaining}`
+      );
+    } catch (error) {
+      console.log('FAILED: Could not consume 2 more tokens');
+    }
+  });
+
+  it('shows behavior with larger over-limit request', async () => {
+    const userId = 'test-user-3';
+
+    console.log('\n=== Large Over-Limit Test ===');
+
+    // Test 3: What about a larger jump over the limit?
+    console.log('\nTest 3: Consuming 800 then 300 tokens');
+    await app.consumeTokens(userId, 800);
+    let usage = await app.getUserUsage(userId);
+    console.log(
+      `After 800: used=${usage.tokens.used}, remaining=${usage.tokens.remaining}`
+    );
+
+    try {
+      await app.consumeTokens(userId, 300);
+      console.log('SUCCESS: Consumed 300 more tokens (now at 1100)');
+      usage = await app.getUserUsage(userId);
+      console.log(
+        `Result: used=${usage.tokens.used}, remaining=${usage.tokens.remaining}`
+      );
+    } catch (error) {
+      console.log('FAILED: Could not consume 300 more tokens');
+      usage = await app.getUserUsage(userId);
+      console.log(
+        `Still at: used=${usage.tokens.used}, remaining=${usage.tokens.remaining}`
+      );
+    }
+  });
+
+  it('shows exact rate limiter behavior for requests', async () => {
+    const userId = 'test-user-2';
+
+    console.log('\n=== Request Rate Limiter Test ===');
+
+    const fakeRequest: any = {
+      user: { userId },
+      userRateLimiters: (app as any).userRateLimiters,
+    };
+    const fakeReply: any = {
+      code: () => fakeReply,
+      send: () => {},
+    };
+
+    let successCount = 0;
+
+    // Try to make 15 requests (limit is 10)
+    for (let i = 1; i <= 15; i++) {
+      try {
+        await app.checkUserRateLimit(fakeRequest, fakeReply);
+        successCount++;
+        console.log(
+          `Request ${i}: SUCCESS (total successful: ${successCount})`
+        );
+      } catch (error) {
+        console.log(`Request ${i}: FAILED - rate limit exceeded`);
+      }
+    }
+
+    const usage = await app.getUserUsage(userId);
+    console.log(`Final usage: ${usage.requests.used} requests`);
+  });
+});

--- a/apps/backend-api/test/routes/api/chat.unit.test.ts
+++ b/apps/backend-api/test/routes/api/chat.unit.test.ts
@@ -81,8 +81,7 @@ describe('Chat Route Unit Tests', () => {
         resetAt: new Date(Date.now() + 3600000).toISOString(),
       },
     }));
-    app.decorate('reserveTokens', async () => {});
-    app.decorate('refundTokens', async () => {});
+    (app as any).decorate('userRateLimiters', { request: {}, token: {} });
 
     // Register chat routes
     await app.register(chatRoutes, { prefix: '/api' });

--- a/package.json
+++ b/package.json
@@ -101,13 +101,14 @@
     "overrides": {
       "underscore": "^1.13.6",
       "happy-dom": "^15.10.2",
-      "esbuild": "^0.25.0"
+      "esbuild": "^0.25.0",
+      "form-data": "^4.0.4"
     }
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.0",
     "@commitlint/config-conventional": "^19.6.0",
-    "@nx/workspace": "^21.2.1",
+    "@nx/workspace": "^21.3.5",
     "@stryker-mutator/core": "^9.0.1",
     "@stryker-mutator/typescript-checker": "^9.0.1",
     "@stryker-mutator/vitest-runner": "^9.0.1",
@@ -125,7 +126,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "markdown-link-check": "^3.13.7",
-    "nx": "21.2.1",
+    "nx": "21.3.5",
     "prettier": "^3.4.2",
     "tsx": "^4.20.3",
     "typescript": "~5.8.2",

--- a/packages/react-sdk/examples/hooks-demo/src/App.css
+++ b/packages/react-sdk/examples/hooks-demo/src/App.css
@@ -44,6 +44,55 @@
   margin-bottom: 16px;
 }
 
+.error.rate-limit {
+  background: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffeaa7;
+}
+
+.usage-info {
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 16px;
+}
+
+.usage-text {
+  font-size: 14px;
+  color: #495057;
+  margin-bottom: 8px;
+}
+
+.usage-progress {
+  height: 8px;
+  background: #e9ecef;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.usage-fill {
+  height: 100%;
+  background: #28a745;
+  transition: width 0.3s ease;
+}
+
+.usage-progress .usage-fill[style*="width: 7"],
+.usage-progress .usage-fill[style*="width: 8"],
+.usage-progress .usage-fill[style*="width: 9"] {
+  background: #ffc107;
+}
+
+.usage-progress .usage-fill[style*="width: 100"] {
+  background: #dc3545;
+}
+
+.usage-reset {
+  font-size: 12px;
+  color: #6c757d;
+}
+
 .input-form {
   display: flex;
   gap: 8px;

--- a/packages/react-sdk/examples/hooks-demo/src/App.tsx
+++ b/packages/react-sdk/examples/hooks-demo/src/App.tsx
@@ -2,10 +2,11 @@ import { useChat } from '@airbolt/react-sdk';
 import './App.css';
 
 export function App() {
-  const { messages, input, setInput, send, isLoading, error, clear } = useChat({
-    baseURL: 'http://localhost:3000', // For production, use your deployed URL like 'https://my-ai-backend.onrender.com'
-    system: 'You are a helpful assistant. Keep responses concise.',
-  });
+  const { messages, input, setInput, send, isLoading, error, clear, usage } =
+    useChat({
+      baseURL: 'http://localhost:3000', // For production, use your deployed URL like 'https://my-ai-backend.onrender.com'
+      system: 'You are a helpful assistant. Keep responses concise.',
+    });
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -16,6 +17,27 @@ export function App() {
     <div className="app">
       <h1>Airbolt Chat Demo</h1>
 
+      {/* Display usage information when available */}
+      {usage && usage.tokens && (
+        <div className="usage-info">
+          <div className="usage-text">
+            Tokens: {usage.tokens.used.toLocaleString()} /{' '}
+            {usage.tokens.limit.toLocaleString()}
+          </div>
+          <div className="usage-progress">
+            <div
+              className="usage-fill"
+              style={{
+                width: `${(usage.tokens.used / usage.tokens.limit) * 100}%`,
+              }}
+            />
+          </div>
+          <div className="usage-reset">
+            Resets at {new Date(usage.tokens.resetAt).toLocaleTimeString()}
+          </div>
+        </div>
+      )}
+
       <div className="messages">
         {messages.map((msg, i) => (
           <div key={i} className={`message ${msg.role}`}>
@@ -25,7 +47,26 @@ export function App() {
         {isLoading && <div className="loading">AI is typing...</div>}
       </div>
 
-      {error && <div className="error">Error: {error.message}</div>}
+      {error && (
+        <div
+          className={`error ${error.message.includes('429') ? 'rate-limit' : ''}`}
+        >
+          {error.message.includes('429') ? (
+            <>
+              Rate limit exceeded.
+              {usage?.tokens && (
+                <>
+                  {' '}
+                  Try again after{' '}
+                  {new Date(usage.tokens.resetAt).toLocaleTimeString()}.
+                </>
+              )}
+            </>
+          ) : (
+            <>Error: {error.message}</>
+          )}
+        </div>
+      )}
 
       <form onSubmit={handleSubmit} className="input-form">
         <input

--- a/packages/react-sdk/src/components/ChatWidget.tsx
+++ b/packages/react-sdk/src/components/ChatWidget.tsx
@@ -123,8 +123,16 @@ export function ChatWidget({
     chatOptions.streaming = streaming;
   }
 
-  const { messages, input, setInput, send, isLoading, isStreaming, error } =
-    useChat(chatOptions);
+  const {
+    messages,
+    input,
+    setInput,
+    send,
+    isLoading,
+    isStreaming,
+    error,
+    usage,
+  } = useChat(chatOptions);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -192,6 +200,22 @@ export function ChatWidget({
       <div style={styles['header']} role="heading" aria-level={2}>
         {title}
       </div>
+
+      {usage && usage.tokens && (
+        <div
+          style={{
+            padding: '0.5rem 1rem',
+            fontSize: '0.875rem',
+            opacity: 0.8,
+            borderBottom: '1px solid var(--airbolt-border)',
+          }}
+          aria-label="Usage information"
+        >
+          Tokens: {usage.tokens.used.toLocaleString()}/
+          {usage.tokens.limit.toLocaleString()} • Resets{' '}
+          {new Date(usage.tokens.resetAt).toLocaleTimeString()}
+        </div>
+      )}
 
       <div
         style={styles['messages']}

--- a/packages/react-sdk/src/hooks/useChat.ts
+++ b/packages/react-sdk/src/hooks/useChat.ts
@@ -175,7 +175,7 @@ export function useChat(options?: UseChatOptions): UseChatReturn {
               setIsStreaming(false);
               // Update usage information from the done event
               if (chunk.usage) {
-                setUsage(chunk.usage as UsageInfo);
+                setUsage(chunk.usage);
               }
             }
             break;

--- a/packages/react-sdk/src/hooks/useChat.ts
+++ b/packages/react-sdk/src/hooks/useChat.ts
@@ -6,6 +6,7 @@ import {
   hasValidToken,
   getTokenInfo,
   type ChatOptions,
+  type UsageInfo,
 } from '@airbolt/sdk';
 import type { UseChatOptions, UseChatReturn, Message } from '../types/index.js';
 
@@ -24,6 +25,7 @@ import type { UseChatOptions, UseChatReturn, Message } from '../types/index.js';
  *     setInput,
  *     send,
  *     isLoading,
+ *     usage,
  *     clearToken,
  *     hasValidToken,
  *     getTokenInfo
@@ -35,6 +37,12 @@ import type { UseChatOptions, UseChatReturn, Message } from '../types/index.js';
  *   return (
  *     <div>
  *       <div>Auth Status: {hasValidToken() ? 'Authenticated' : 'Not authenticated'}</div>
+ *       {usage && (
+ *         <div>
+ *           Tokens: {usage.tokens?.used}/{usage.tokens?.limit}
+ *           (resets {new Date(usage.tokens?.resetAt || '').toLocaleTimeString()})
+ *         </div>
+ *       )}
  *       {messages.map((m, i) => (
  *         <div key={i}>
  *           <b>{m.role}:</b> {m.content}
@@ -67,6 +75,7 @@ export function useChat(options?: UseChatOptions): UseChatReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [usage, setUsage] = useState<UsageInfo | null>(null);
 
   // Use ref to track if component is mounted to prevent state updates after unmount
   const isMountedRef = useRef(false);
@@ -164,6 +173,10 @@ export function useChat(options?: UseChatOptions): UseChatReturn {
           } else if (chunk.type === 'done') {
             if (isMountedRef.current) {
               setIsStreaming(false);
+              // Update usage information from the done event
+              if (chunk.usage) {
+                setUsage(chunk.usage as UsageInfo);
+              }
             }
             break;
           }
@@ -176,10 +189,14 @@ export function useChat(options?: UseChatOptions): UseChatReturn {
         if (isMountedRef.current) {
           const assistantMessage: Message = {
             role: 'assistant',
-            content: response,
+            content: response.content,
           };
           setMessages(prev => [...prev, assistantMessage]);
           setIsLoading(false);
+          // Update usage information from the response
+          if (response.usage) {
+            setUsage(response.usage);
+          }
         }
       }
     } catch (err) {
@@ -206,6 +223,7 @@ export function useChat(options?: UseChatOptions): UseChatReturn {
     setError(null);
     setIsLoading(false);
     setIsStreaming(false);
+    setUsage(null);
     // Cancel any pending requests
     abortControllerRef.current?.abort();
   }, []);
@@ -230,6 +248,7 @@ export function useChat(options?: UseChatOptions): UseChatReturn {
     isLoading,
     isStreaming,
     error,
+    usage,
     send,
     clear,
     clearToken,

--- a/packages/react-sdk/src/types/index.ts
+++ b/packages/react-sdk/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { Message, TokenInfo } from '@airbolt/sdk';
+import type { Message, TokenInfo, UsageInfo } from '@airbolt/sdk';
 
 /**
  * Options for the useChat hook
@@ -64,6 +64,10 @@ export interface UseChatReturn {
    */
   error: Error | null;
   /**
+   * Usage information from the last response
+   */
+  usage: UsageInfo | null;
+  /**
    * Send the current input as a message
    */
   send: () => Promise<void>;
@@ -88,4 +92,4 @@ export interface UseChatReturn {
 /**
  * Re-export types from SDK for convenience
  */
-export type { Message, TokenInfo } from '@airbolt/sdk';
+export type { Message, TokenInfo, UsageInfo } from '@airbolt/sdk';

--- a/packages/react-sdk/test/components/ChatWidget.styling.test.tsx
+++ b/packages/react-sdk/test/components/ChatWidget.styling.test.tsx
@@ -39,6 +39,7 @@ describe('ChatWidget Styling', () => {
     isLoading: false,
     isStreaming: false,
     error: null,
+    usage: null,
     clearToken: vi.fn(),
     hasValidToken: vi.fn(() => true),
     getTokenInfo: vi.fn(() => ({ hasToken: true })),

--- a/packages/react-sdk/test/components/ChatWidget.test.tsx
+++ b/packages/react-sdk/test/components/ChatWidget.test.tsx
@@ -37,6 +37,7 @@ describe('ChatWidget XSS Protection', () => {
     isLoading: false,
     isStreaming: false,
     error: null,
+    usage: null,
     clearToken: vi.fn(),
     hasValidToken: vi.fn(() => true),
     getTokenInfo: vi.fn(() => ({ hasToken: true })),

--- a/packages/sdk/examples/node-cli/index.js
+++ b/packages/sdk/examples/node-cli/index.js
@@ -7,12 +7,14 @@
  * Just run: npm start
  */
 
-import { chat } from '@airbolt/sdk';
+import { chat, chatSync } from '@airbolt/sdk';
 
 async function main() {
-  console.log('🤖 Airbolt Chat Example\n');
+  console.log('🤖 Airbolt Chat Example with Usage Tracking\n');
 
   try {
+    // Example 1: Streaming with usage info
+    console.log('📡 Streaming Example:\n');
     const messages = [
       { role: 'user', content: 'Hello! Can you tell me a short joke?' },
     ];
@@ -20,22 +22,66 @@ async function main() {
     console.log('User:', messages[0].content);
     console.log('\nAI: ');
 
-    // Stream the response (default behavior)
+    let usage;
+
+    // Stream the response and capture usage info
     for await (const chunk of chat(messages, {
       baseURL: 'http://localhost:3000', // For production, use your deployed URL like 'https://my-ai-backend.onrender.com'
     })) {
       if (chunk.type === 'chunk') {
         process.stdout.write(chunk.content);
+      } else if (chunk.type === 'done' && chunk.usage) {
+        usage = chunk.usage;
       }
     }
 
+    // Display usage information
+    if (usage) {
+      console.log('\n\n📊 Usage Information:');
+      console.log(`  - Total tokens used: ${usage.total_tokens}`);
+
+      if (usage.tokens) {
+        console.log(
+          `  - Token usage: ${usage.tokens.used}/${usage.tokens.limit}`
+        );
+        console.log(`  - Remaining: ${usage.tokens.remaining} tokens`);
+        console.log(
+          `  - Resets at: ${new Date(usage.tokens.resetAt).toLocaleTimeString()}`
+        );
+      }
+    }
+
+    // Example 2: Non-streaming with usage info
+    console.log('\n\n🔄 Non-Streaming Example:\n');
+    const response = await chatSync(
+      [{ role: 'user', content: 'What is Node.js in one sentence?' }],
+      { baseURL: 'http://localhost:3000' }
+    );
+
+    console.log('User: What is Node.js in one sentence?');
+    console.log('\nAI:', response.content);
+
+    if (response.usage) {
+      console.log(
+        `\n📊 This request used ${response.usage.total_tokens} tokens`
+      );
+    }
+
     console.log(
-      '\n\n✅ Success! The SDK handles authentication and streaming automatically.'
+      '\n\n✅ Success! The SDK handles authentication, streaming, and usage tracking automatically.'
     );
   } catch (error) {
     console.error('\n❌ Error:', error.message);
-    console.log('\nMake sure the backend is running:');
-    console.log('  cd apps/backend-api && pnpm dev');
+
+    // Handle rate limit errors
+    if (error.message.includes('429')) {
+      console.log('\n⚠️  Rate limit exceeded!');
+      console.log('The SDK automatically retries with exponential backoff.');
+      console.log('If you continue to see this, wait before trying again.');
+    } else {
+      console.log('\nMake sure the backend is running:');
+      console.log('  cd apps/backend-api && pnpm dev');
+    }
   }
 }
 

--- a/packages/sdk/examples/node-cli/index.ts
+++ b/packages/sdk/examples/node-cli/index.ts
@@ -7,36 +7,111 @@
  * Run with: npm run start:ts
  */
 
-import { chat, type Message } from '@airbolt/sdk';
+import { chat, chatSync, type Message, type UsageInfo } from '@airbolt/sdk';
 
-async function main(): Promise<void> {
-  console.log('🤖 Airbolt Chat Example (TypeScript)\n');
+async function displayUsage(usage: UsageInfo | undefined): Promise<void> {
+  if (usage) {
+    console.log('\n📊 Usage Information:');
+    console.log(`  - Total tokens: ${usage.total_tokens}`);
 
-  try {
-    // Type-safe message array
-    const messages: Message[] = [
-      { role: 'user', content: 'What is TypeScript?' },
-    ];
-
-    console.log('User:', messages[0].content);
-    console.log('\nAI: ');
-
-    // Stream response with typed options (default behavior)
-    for await (const chunk of chat(messages, {
-      baseURL: process.env.AIRBOLT_URL || 'http://localhost:3000', // For production, use your deployed URL like 'https://my-ai-backend.onrender.com'
-      system: 'You are a helpful assistant. Keep responses concise.',
-    })) {
-      if (chunk.type === 'chunk') {
-        process.stdout.write(chunk.content);
-      }
+    if (usage.tokens) {
+      const percentUsed = (
+        (usage.tokens.used / usage.tokens.limit) *
+        100
+      ).toFixed(1);
+      console.log(
+        `  - Token usage: ${usage.tokens.used}/${usage.tokens.limit} (${percentUsed}%)`
+      );
+      console.log(`  - Remaining: ${usage.tokens.remaining} tokens`);
+      console.log(
+        `  - Resets at: ${new Date(usage.tokens.resetAt).toLocaleTimeString()}`
+      );
     }
 
-    console.log('\n\n✅ Full type safety with TypeScript and streaming!');
+    if (usage.requests) {
+      console.log(
+        `  - Request usage: ${usage.requests.used}/${usage.requests.limit}`
+      );
+      console.log(
+        `  - Resets at: ${new Date(usage.requests.resetAt).toLocaleTimeString()}`
+      );
+    }
+  }
+}
+
+async function streamingExample(): Promise<void> {
+  console.log('📡 Streaming Example:\n');
+
+  const messages: Message[] = [
+    { role: 'user', content: 'What is TypeScript in 2 sentences?' },
+  ];
+
+  console.log('User:', messages[0].content);
+  console.log('\nAI: ');
+
+  let usage: UsageInfo | undefined;
+
+  // Stream response with typed options (default behavior)
+  for await (const chunk of chat(messages, {
+    baseURL: process.env.AIRBOLT_URL || 'http://localhost:3000',
+    system: 'You are a helpful assistant. Keep responses concise.',
+  })) {
+    if (chunk.type === 'chunk') {
+      process.stdout.write(chunk.content);
+    } else if (chunk.type === 'done' && chunk.usage) {
+      usage = chunk.usage;
+    }
+  }
+
+  await displayUsage(usage);
+}
+
+async function nonStreamingExample(): Promise<void> {
+  console.log('\n\n🔄 Non-Streaming Example:\n');
+
+  const messages: Message[] = [
+    { role: 'user', content: 'What is JavaScript in 2 sentences?' },
+  ];
+
+  console.log('User:', messages[0].content);
+
+  // Get complete response at once with usage info
+  const response = await chatSync(messages, {
+    baseURL: process.env.AIRBOLT_URL || 'http://localhost:3000',
+    system: 'You are a helpful assistant. Keep responses concise.',
+  });
+
+  console.log('\nAI:', response.content);
+  await displayUsage(response.usage);
+}
+
+async function main(): Promise<void> {
+  console.log('🤖 Airbolt Chat Example with Rate Limiting (TypeScript)\n');
+
+  try {
+    // Run both examples
+    await streamingExample();
+    await nonStreamingExample();
+
+    console.log('\n\n✅ Full type safety with TypeScript and usage tracking!');
   } catch (error) {
-    console.error(
-      '\n❌ Error:',
-      error instanceof Error ? error.message : 'Unknown error'
-    );
+    if (error instanceof Error) {
+      console.error('\n❌ Error:', error.message);
+
+      // Handle rate limit errors specifically
+      if (error.message.includes('429')) {
+        console.log('\n⚠️  Rate limit exceeded!');
+        console.log(
+          'The SDK will automatically retry with exponential backoff.'
+        );
+        console.log(
+          'If you continue to see this error, wait a moment before trying again.'
+        );
+      }
+    } else {
+      console.error('\n❌ Unknown error:', error);
+    }
+
     console.log('\nMake sure the backend is running:');
     console.log('  cd apps/backend-api && pnpm dev');
   }

--- a/packages/sdk/src/api/chat.ts
+++ b/packages/sdk/src/api/chat.ts
@@ -4,6 +4,45 @@ import { AirboltError } from '../core/errors.js';
 import { joinUrl } from '../core/url-utils.js';
 
 /**
+ * Parse rate limit information from response headers
+ */
+function parseRateLimitHeaders(headers: Headers): Partial<UsageInfo> | null {
+  const requestsLimit = headers.get('x-ratelimit-requests-limit');
+  const requestsRemaining = headers.get('x-ratelimit-requests-remaining');
+  const requestsReset = headers.get('x-ratelimit-requests-reset');
+
+  const tokensLimit = headers.get('x-ratelimit-tokens-limit');
+  const tokensRemaining = headers.get('x-ratelimit-tokens-remaining');
+  const tokensReset = headers.get('x-ratelimit-tokens-reset');
+
+  if (!requestsLimit && !tokensLimit) {
+    return null;
+  }
+
+  const result: Partial<UsageInfo> = {};
+
+  if (requestsLimit && requestsRemaining && requestsReset) {
+    result.requests = {
+      used: parseInt(requestsLimit) - parseInt(requestsRemaining),
+      remaining: parseInt(requestsRemaining),
+      limit: parseInt(requestsLimit),
+      resetAt: new Date(parseInt(requestsReset) * 1000).toISOString(),
+    };
+  }
+
+  if (tokensLimit && tokensRemaining && tokensReset) {
+    result.tokens = {
+      used: parseInt(tokensLimit) - parseInt(tokensRemaining),
+      remaining: parseInt(tokensRemaining),
+      limit: parseInt(tokensLimit),
+      resetAt: new Date(parseInt(tokensReset) * 1000).toISOString(),
+    };
+  }
+
+  return result;
+}
+
+/**
  * Send a chat message to Airbolt and receive a complete response (non-streaming)
  *
  * Note: For the default streaming behavior, use `chat()` instead.
@@ -117,6 +156,9 @@ export async function* chatStream(
       throw new AirboltError('Response body is not readable', 500);
     }
 
+    // Parse rate limit headers if present
+    const rateLimitInfo = parseRateLimitHeaders(response.headers);
+
     const decoder = new TextDecoder();
     let buffer = '';
 
@@ -184,7 +226,7 @@ export async function* chatStream(
                     };
                   };
                   usage = {
-                    total_tokens: usageData.total_tokens || 0,
+                    total_tokens: usageData.total_tokens ?? 0,
                     // Include rate limit usage if present
                     ...(usageData.tokens && {
                       tokens: usageData.tokens,
@@ -192,9 +234,23 @@ export async function* chatStream(
                     ...(usageData.requests && {
                       requests: usageData.requests,
                     }),
-                  };
+                  } as UsageInfo;
                 }
-                yield { content: '', type: 'done', usage: usage as UsageInfo };
+
+                // Merge rate limit info from headers if available
+                if (rateLimitInfo) {
+                  usage = {
+                    ...usage,
+                    ...rateLimitInfo,
+                    total_tokens: usage?.total_tokens ?? 0,
+                  } as UsageInfo;
+                }
+
+                yield {
+                  content: '',
+                  type: 'done',
+                  usage: usage ? usage : undefined,
+                };
                 return;
               case 'error':
                 throw new AirboltError(

--- a/packages/sdk/src/api/index.ts
+++ b/packages/sdk/src/api/index.ts
@@ -7,5 +7,12 @@ export { createChatSession } from './session.js';
 export { clearAuthToken, hasValidToken, getTokenInfo } from './client-utils.js';
 
 // Type exports
-export type { Message, ChatOptions, ChatSession } from './types.js';
+export type {
+  Message,
+  ChatOptions,
+  ChatSession,
+  UsageInfo,
+  ChatResponse,
+  StreamChunk,
+} from './types.js';
 export type { TokenInfo } from './client-utils.js';

--- a/packages/sdk/src/api/session.ts
+++ b/packages/sdk/src/api/session.ts
@@ -47,12 +47,12 @@ export function createChatSession(options?: ChatOptions): ChatSession {
 
       // Get response with full conversation history
       // Pass a copy to prevent mutation issues
-      const reply = await chatSync([...messages], options);
+      const response = await chatSync([...messages], options);
 
       // Add assistant response to history
-      messages.push({ role: 'assistant', content: reply });
+      messages.push({ role: 'assistant', content: response.content });
 
-      return reply;
+      return response.content;
     },
 
     getMessages(): readonly Message[] {

--- a/packages/sdk/src/api/types.ts
+++ b/packages/sdk/src/api/types.ts
@@ -2,7 +2,7 @@
  * Message format for chat interactions
  */
 export interface Message {
-  role: 'user' | 'assistant';
+  role: 'user' | 'assistant' | 'system';
   content: string;
 }
 
@@ -50,4 +50,47 @@ export interface ChatSession {
    * Clear all messages from the session
    */
   clear(): void;
+}
+
+/**
+ * Usage information returned by the API
+ */
+export interface UsageInfo {
+  /** Total tokens consumed by this request */
+  total_tokens: number;
+  /** User's current rate limit usage (if rate limiting is enabled) */
+  tokens?: {
+    used: number;
+    remaining: number;
+    limit: number;
+    resetAt: string;
+  };
+  requests?: {
+    used: number;
+    remaining: number;
+    limit: number;
+    resetAt: string;
+  };
+}
+
+/**
+ * Response from the chat API including usage information
+ */
+export interface ChatResponse {
+  /** The AI assistant's response content */
+  content: string;
+  /** Usage information for this request */
+  usage?: UsageInfo;
+}
+
+/**
+ * Streaming response chunk
+ */
+export interface StreamChunk {
+  /** Content chunk from the assistant */
+  content: string;
+  /** Type of chunk */
+  type: 'chunk' | 'done' | 'error';
+  /** Usage information (only present in 'done' chunks) */
+  usage?: UsageInfo;
 }

--- a/packages/sdk/src/core/url-utils.ts
+++ b/packages/sdk/src/core/url-utils.ts
@@ -62,7 +62,9 @@ export function joinUrl(base: string, ...segments: string[]): string {
       const trimmed = normalized.trim();
       // Then remove leading and trailing slashes
       const withoutSlashes = trimmed.replace(/^\/+|\/+$/g, '');
-      return withoutSlashes;
+      // Also normalize any double slashes within the segment
+      const cleanedSegment = withoutSlashes.replace(/\/+/g, '/');
+      return cleanedSegment;
     })
     .filter(segment => segment.length > 0);
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -33,6 +33,9 @@ export type {
   ChatOptions,
   ChatSession,
   TokenInfo,
+  UsageInfo,
+  ChatResponse,
+  StreamChunk,
 } from './api/index.js';
 
 // Default export for convenience

--- a/packages/sdk/test/api/chat.property.test.ts
+++ b/packages/sdk/test/api/chat.property.test.ts
@@ -41,7 +41,9 @@ describe('chatSync - property-based tests', () => {
 
           const result = await chatSync(messages as Message[]);
 
-          expect(result).toBe(expectedResponse);
+          expect(result.content).toBe(expectedResponse);
+          expect(result.usage).toBeDefined();
+          expect(result.usage?.total_tokens).toBe(10);
           expect(mockChat).toHaveBeenCalledWith(messages, {
             provider: undefined,
             model: undefined,
@@ -150,7 +152,9 @@ describe('chatSync - property-based tests', () => {
 
       const result = await chatSync(messages);
 
-      expect(result).toBe('Safe response');
+      expect(result.content).toBe('Safe response');
+      expect(result.usage).toBeDefined();
+      expect(result.usage?.total_tokens).toBe(10);
       expect(mockChat).toHaveBeenCalledWith([{ role: 'user', content }], {
         provider: undefined,
         model: undefined,

--- a/packages/sdk/test/api/chat.test.ts
+++ b/packages/sdk/test/api/chat.test.ts
@@ -37,7 +37,9 @@ describe('chatSync', () => {
 
     const result = await chatSync(messages);
 
-    expect(result).toBe(expectedResponse);
+    expect(result.content).toBe(expectedResponse);
+    expect(result.usage).toBeDefined();
+    expect(result.usage?.total_tokens).toBe(15);
     expect(mockClientConstructor).toHaveBeenCalledWith({
       baseURL: 'http://localhost:3000',
     });
@@ -95,7 +97,9 @@ describe('chatSync', () => {
 
     const result = await chatSync(messages);
 
-    expect(result).toBe('3+3 equals 6');
+    expect(result.content).toBe('3+3 equals 6');
+    expect(result.usage).toBeDefined();
+    expect(result.usage?.total_tokens).toBe(30);
     expect(mockChat).toHaveBeenCalledWith(messages, {
       provider: undefined,
       model: undefined,
@@ -121,7 +125,9 @@ describe('chatSync', () => {
 
     const result = await chatSync(messages);
 
-    expect(result).toBe('No messages provided');
+    expect(result.content).toBe('No messages provided');
+    expect(result.usage).toBeDefined();
+    expect(result.usage?.total_tokens).toBe(5);
     expect(mockChat).toHaveBeenCalledWith([], {
       provider: undefined,
       model: undefined,

--- a/packages/sdk/test/api/session.test.ts
+++ b/packages/sdk/test/api/session.test.ts
@@ -34,7 +34,7 @@ describe('createChatSession', () => {
   it('should send messages and track conversation history', async () => {
     const session = createChatSession();
 
-    mockChat.mockResolvedValueOnce('Hello! How can I help you?');
+    mockChat.mockResolvedValueOnce({ content: 'Hello! How can I help you?' });
 
     const response = await session.send('Hello');
 
@@ -55,11 +55,11 @@ describe('createChatSession', () => {
     const session = createChatSession();
 
     // First exchange
-    mockChat.mockResolvedValueOnce('2+2 equals 4');
+    mockChat.mockResolvedValueOnce({ content: '2+2 equals 4' });
     await session.send('What is 2+2?');
 
     // Second exchange - should include full history
-    mockChat.mockResolvedValueOnce('You asked what 2+2 equals');
+    mockChat.mockResolvedValueOnce({ content: 'You asked what 2+2 equals' });
     const response = await session.send('What did I just ask?');
 
     expect(response).toBe('You asked what 2+2 equals');
@@ -80,7 +80,7 @@ describe('createChatSession', () => {
     const baseURL = 'https://custom.api.com';
     const session = createChatSession({ baseURL });
 
-    mockChat.mockResolvedValueOnce('Response');
+    mockChat.mockResolvedValueOnce({ content: 'Response' });
 
     await session.send('Test');
 
@@ -97,7 +97,7 @@ describe('createChatSession', () => {
     };
     const session = createChatSession(options);
 
-    mockChat.mockResolvedValueOnce('Response from Claude');
+    mockChat.mockResolvedValueOnce({ content: 'Response from Claude' });
 
     await session.send('Test');
 
@@ -121,7 +121,7 @@ describe('createChatSession', () => {
   it('should clear all messages when clear() is called', async () => {
     const session = createChatSession();
 
-    mockChat.mockResolvedValueOnce('First response');
+    mockChat.mockResolvedValueOnce({ content: 'First response' });
     await session.send('First message');
 
     expect(session.getMessages()).toHaveLength(2);
@@ -135,14 +135,14 @@ describe('createChatSession', () => {
     const session = createChatSession();
 
     // First message
-    mockChat.mockResolvedValueOnce('First response');
+    mockChat.mockResolvedValueOnce({ content: 'First response' });
     await session.send('First');
 
     // Clear
     session.clear();
 
     // New message after clear
-    mockChat.mockResolvedValueOnce('New response');
+    mockChat.mockResolvedValueOnce({ content: 'New response' });
     const response = await session.send('New message');
 
     expect(response).toBe('New response');
@@ -169,7 +169,7 @@ describe('createChatSession', () => {
   it('should handle empty messages', async () => {
     const session = createChatSession();
 
-    mockChat.mockResolvedValueOnce('Empty message response');
+    mockChat.mockResolvedValueOnce({ content: 'Empty message response' });
 
     const response = await session.send('');
 
@@ -184,10 +184,10 @@ describe('createChatSession', () => {
     const session1 = createChatSession();
     const session2 = createChatSession();
 
-    mockChat.mockResolvedValueOnce('Response 1');
+    mockChat.mockResolvedValueOnce({ content: 'Response 1' });
     await session1.send('Message 1');
 
-    mockChat.mockResolvedValueOnce('Response 2');
+    mockChat.mockResolvedValueOnce({ content: 'Response 2' });
     await session2.send('Message 2');
 
     expect(session1.getMessages()).toHaveLength(2);

--- a/packages/sdk/test/chat-streaming.test.ts
+++ b/packages/sdk/test/chat-streaming.test.ts
@@ -21,6 +21,7 @@ describe('chatStream', () => {
     // Mock SSE response
     const mockResponse = {
       ok: true,
+      headers: new Headers(),
       body: new ReadableStream({
         start(controller) {
           const encoder = new TextEncoder();

--- a/packages/sdk/test/core/cold-start-retry.test.ts
+++ b/packages/sdk/test/core/cold-start-retry.test.ts
@@ -63,6 +63,7 @@ describe('AirboltClient cold start retry', () => {
 
       expect(mockSendChat).toHaveBeenCalledWith(expect.any(Object), {
         timeoutInSeconds: 30,
+        maxRetries: 3,
       });
     });
 
@@ -80,6 +81,7 @@ describe('AirboltClient cold start retry', () => {
 
       expect(mockSendChat).toHaveBeenCalledWith(expect.any(Object), {
         timeoutInSeconds: 60,
+        maxRetries: 3,
       });
     });
   });
@@ -113,11 +115,13 @@ describe('AirboltClient cold start retry', () => {
       // First call with normal timeout
       expect(mockSendChat).toHaveBeenNthCalledWith(1, expect.any(Object), {
         timeoutInSeconds: 45,
+        maxRetries: 3,
       });
 
       // Second call with double timeout
       expect(mockSendChat).toHaveBeenNthCalledWith(2, expect.any(Object), {
         timeoutInSeconds: 90,
+        maxRetries: 3,
       });
 
       // Callback should have been called

--- a/packages/sdk/test/core/fern-client.test.ts
+++ b/packages/sdk/test/core/fern-client.test.ts
@@ -120,8 +120,10 @@ describe('AirboltClient (Fern-based)', () => {
       expect(mockSendChatMessagesToAi).toHaveBeenCalledWith(
         {
           messages: [{ role: 'user', content: 'Hello' }],
+          provider: undefined,
+          model: undefined,
         },
-        { timeoutInSeconds: 60 }
+        { timeoutInSeconds: 60, maxRetries: 3 }
       );
 
       expect(response).toEqual({
@@ -143,8 +145,10 @@ describe('AirboltClient (Fern-based)', () => {
       expect(mockSendChatMessagesToAi).toHaveBeenCalledWith(
         {
           messages: messages.map(m => ({ role: m.role, content: m.content })),
+          provider: undefined,
+          model: undefined,
         },
-        { timeoutInSeconds: 60 }
+        { timeoutInSeconds: 60, maxRetries: 3 }
       );
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       openai:
         specifier: ^5.8.2
         version: 5.9.0(zod@3.25.76)
+      rate-limiter-flexible:
+        specifier: ^7.1.1
+        version: 7.1.1
       zod:
         specifier: ^3.25.67
         version: 3.25.76
@@ -4482,6 +4485,9 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  rate-limiter-flexible@7.1.1:
+    resolution: {integrity: sha512-lsYRcqRSJrKBNt6pMzBJTiCJP5KnwsGWdObMZxd19JFUJRntM+yuHs4/2bs6NZweSLgpsDcykvzyQaumoslWQg==}
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -10591,6 +10597,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  rate-limiter-flexible@7.1.1: {}
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   underscore: ^1.13.6
   happy-dom: ^15.10.2
   esbuild: ^0.25.0
+  form-data: ^4.0.4
 
 importers:
 
@@ -27,8 +28,8 @@ importers:
         specifier: ^19.6.0
         version: 19.8.1
       '@nx/workspace':
-        specifier: ^21.2.1
-        version: 21.2.3(@swc/core@1.13.1)
+        specifier: ^21.3.5
+        version: 21.3.5(@swc/core@1.13.1)
       '@stryker-mutator/core':
         specifier: ^9.0.1
         version: 9.0.1(@types/node@22.16.3)
@@ -81,8 +82,8 @@ importers:
         specifier: ^3.13.7
         version: 3.13.7
       nx:
-        specifier: 21.2.1
-        version: 21.2.1(@swc/core@1.13.1)
+        specifier: 21.3.5
+        version: 21.3.5(@swc/core@1.13.1)
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
@@ -731,14 +732,14 @@ packages:
     resolution: {integrity: sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==}
     engines: {node: '>=v18'}
 
-  '@emnapi/core@1.4.4':
-    resolution: {integrity: sha512-A9CnAbC6ARNMKcIcrQwq6HeHCjpcBZ5wSx4U01WXCqEKlrzB9F9315WDNHkrs2xbx7YjjSxbUYxuN6EQzpcY2g==}
+  '@emnapi/core@1.4.5':
+    resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
 
-  '@emnapi/runtime@1.4.4':
-    resolution: {integrity: sha512-hHyapA4A3gPaDCNfiqyZUStTMqIkKRshqPIuDOXv1hcBnD4U3l8cP0T1HMCfGRxQ6V64TGCcoswChANyOAwbQg==}
+  '@emnapi/runtime@1.4.5':
+    resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
 
-  '@emnapi/wasi-threads@1.0.3':
-    resolution: {integrity: sha512-8K5IFFsQqF9wQNJptGbS6FNKgUTsSRYnTqNCG1vPP8jFdjSv18n2mQfJpkt2Oibo9iBEzcDnDxNwKTzC7svlJw==}
+  '@emnapi/wasi-threads@1.0.4':
+    resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
 
   '@esbuild/aix-ppc64@0.25.6':
     resolution: {integrity: sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==}
@@ -1142,9 +1143,17 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  '@jest/schemas@29.6.3':
-    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  '@jest/diff-sequences@30.0.1':
+    resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/get-type@30.0.1':
+    resolution: {integrity: sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/schemas@30.0.5':
+    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
@@ -1211,113 +1220,63 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nx/devkit@21.2.3':
-    resolution: {integrity: sha512-H5Hk0qeZwqhxQmqcWaLpMc+otU4TroUzDYoV6kFpZdvcwGnXQKHCuGzZoI18kh9wPXvKFmb1BWmr9as3lHUw3Q==}
+  '@nx/devkit@21.3.5':
+    resolution: {integrity: sha512-YTmjD+kqDUapfcV37IgVddLZL4oOoFVXO0dFKsYSkx/FNmhccTbeXxgsdcyRTJY6gCwsFJ+4X0aIv8NxebWYaw==}
     peerDependencies:
-      nx: 21.2.3
+      nx: 21.3.5
 
-  '@nx/nx-darwin-arm64@21.2.1':
-    resolution: {integrity: sha512-iP5N5TAe4k9j2p4xhEXU/a/6qEW6PWbRQeSSbCsFLuvf4UslP7wW6vuzteSW1r48Aras+5lGUOERtrlnKnuTew==}
+  '@nx/nx-darwin-arm64@21.3.5':
+    resolution: {integrity: sha512-QKWtKjIdYS2foDo/4ojvVr5NjrtY8IcHPyFFATAk7v5BWe2tEGh6pPDj8GRqvSqZPWSBZNDcJ6efovJyka6yzw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@nx/nx-darwin-arm64@21.2.3':
-    resolution: {integrity: sha512-5WgOjoX4vqG286A8abYoLCScA2ZF5af/2ZBjaM5EHypgbJLGQuMcP2ahzX66FYohT4wdAej1D0ILkEax71fAKw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@nx/nx-darwin-x64@21.2.1':
-    resolution: {integrity: sha512-CFRBYwUvQIYG+DPoNF2wzjCFSNn0tfN9WlHDJWI41qZNZfc4kSY8zQYDLXNj4/Lp7XMBL+Sv70Dd9mDzfnP2Cg==}
+  '@nx/nx-darwin-x64@21.3.5':
+    resolution: {integrity: sha512-X06eb6lzuln9ZHh7L8430s4Cc7pi5mihU3IlJsN0rbgdCp2PMlOsJ/8P/zw/DBwq6qmTuVwZ8Xk01VOVtWZT0w==}
     cpu: [x64]
     os: [darwin]
 
-  '@nx/nx-darwin-x64@21.2.3':
-    resolution: {integrity: sha512-aSaK8Ic9nHTwSuNZZtaKCPIXgD6+Ss9UwkNMIXPLYiYLF+EdSDORHnHutmajZZ8HakoWCQPWvxfWv30zre6iqw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@nx/nx-freebsd-x64@21.2.1':
-    resolution: {integrity: sha512-r2J6CrPwibsvCjMYQ7OqdpSF6HW1lI/+HghMh/cAeTQiCC2ksVeXR/WX2QkFkBhyo1pAbQilbxLUQOYEl8qL3A==}
+  '@nx/nx-freebsd-x64@21.3.5':
+    resolution: {integrity: sha512-+ZWvAn/1UD4Wwduv5nhcXWIUcev1JDEEsNBesGvFWS4c19dBk8vaUpUv3YQspwRUgAGdfYw1CWqDDOYvGFrZ3w==}
     cpu: [x64]
     os: [freebsd]
 
-  '@nx/nx-freebsd-x64@21.2.3':
-    resolution: {integrity: sha512-hFSbtaYM1gL+XQq88CkmwqeeabmFsLjpsBF+HFIv1UMAjb02ObrYHVVICmmin5c1NkBsEJcQzh3mf8PBSOHW8A==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@nx/nx-linux-arm-gnueabihf@21.2.1':
-    resolution: {integrity: sha512-h7G/OQ0iEiKmcvBKiWycwx3RS+C3X997iDMhQLlJEKno2boUKpEXuz4T1uMBLdGdc6r+XElsaEMJYKxpIy8Fvw==}
+  '@nx/nx-linux-arm-gnueabihf@21.3.5':
+    resolution: {integrity: sha512-JeSw0/WdVo4AxCKWRrH686rxu9jHzKnl/IY1m+/jiIPq2yUPUUxqSj9+Xesvp9K3plAmZFlSulbfd8BX15/cEw==}
     cpu: [arm]
     os: [linux]
 
-  '@nx/nx-linux-arm-gnueabihf@21.2.3':
-    resolution: {integrity: sha512-yRzt8dLwTpRP7655We9/ol+Ol+n52R9wsRRnxJFdWHyLrHguZF0dqiZ5rAFFzyvywaDP6CRoPuS7wqFT7K14bw==}
-    cpu: [arm]
-    os: [linux]
-
-  '@nx/nx-linux-arm64-gnu@21.2.1':
-    resolution: {integrity: sha512-Cc1MIZHZEkY60xWuCxoTRDCbdezSyDNnziH9OUnJrCTB09EvDjUv+x9wyOYyBCfcGeU1b1L1icGKw7cS/CZwVw==}
+  '@nx/nx-linux-arm64-gnu@21.3.5':
+    resolution: {integrity: sha512-TlMhwwj75cP67m/qYuSAmvdMMW6oASELo3uxRJ9PbpyTRiCmQZoqjZqALL/48rAEk1Ig69o83RI4pIMRkGMQUw==}
     cpu: [arm64]
     os: [linux]
 
-  '@nx/nx-linux-arm64-gnu@21.2.3':
-    resolution: {integrity: sha512-5u8mmUogvrNn1xlJk8Y6AJg/g1h2bKxYSyWfxR2mazKj5wI/VgbHuxHAgMXB7WDW2tK5bEcrUTvO8V0DjZQhNA==}
+  '@nx/nx-linux-arm64-musl@21.3.5':
+    resolution: {integrity: sha512-GZBMLTJFP9H9/o26jSfqxwlBoZ4c0FNBl8rJ3tOC9jCNHn7wcMJKaVbp0dUKDgUtyzATa5poJsdClG84zMnHdA==}
     cpu: [arm64]
     os: [linux]
 
-  '@nx/nx-linux-arm64-musl@21.2.1':
-    resolution: {integrity: sha512-L0c59PWMmU66tYQG4Ume8dCvUChVvxW1B0iAyb1vSEB4sLQgdCIn44uxwmb3+0qIeex2RJlFt7FyI+ey5AfUvQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@nx/nx-linux-arm64-musl@21.2.3':
-    resolution: {integrity: sha512-4huuq2iuCBOWmJQw60gk5g3yjeHxFzwdDZJPM0680fZ7Pa/haPwamkR6kE2U6aFtFMhi1QVGPEoj4v4vE4ZS5g==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@nx/nx-linux-x64-gnu@21.2.1':
-    resolution: {integrity: sha512-E72abpUPT41DmgOmteTbcuiyRW0lY+3i9lq0drOjr1LApUJs+/HTa3W6K1qAGwZ6vn0XDOdYyG5jhFGzNl1pOg==}
+  '@nx/nx-linux-x64-gnu@21.3.5':
+    resolution: {integrity: sha512-rNZ2X+h3AbF+vM3zKcpv122Eu5fyYS0079iNiYAHNknwLPJUlvDEQU3nu6ts8Hw1zSjxzibHbWZghSfZRAIHZA==}
     cpu: [x64]
     os: [linux]
 
-  '@nx/nx-linux-x64-gnu@21.2.3':
-    resolution: {integrity: sha512-qWpJXpF8vjOrZTkgSC8kQAnIh0pIFbsisePicYWj5U9szJYyTUvVbjMAvdUPH4Z3bnrUtt+nzf9mpFCJRLjsOQ==}
+  '@nx/nx-linux-x64-musl@21.3.5':
+    resolution: {integrity: sha512-LtsDUhrH0sVl7gBSsJ+cy/cKH71PorysOhJqTrE7Z5UVpnWu+1djiOsbEDRAheyUf80QfFA8xC239Pi+QG3T/w==}
     cpu: [x64]
     os: [linux]
 
-  '@nx/nx-linux-x64-musl@21.2.1':
-    resolution: {integrity: sha512-aBt7BP0tMRx/iRUkuJnLQykQA/YO2phC6moPNxx+DHfricjI77gWWal/FlKQsM7g/bAoXPQw0QSG/ifvrJnUUA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@nx/nx-linux-x64-musl@21.2.3':
-    resolution: {integrity: sha512-JZHlovF9uzvN3blImysYJmG90/8ookr3jOmEFxmP4RfMUl6EdN9yBLBdx0zIG2ulh7+WQrR3eQ1qrmsWFb6oiw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@nx/nx-win32-arm64-msvc@21.2.1':
-    resolution: {integrity: sha512-NTGSDk6i9L3OEreBmlCaCAYHLRjHuyk3rCbX+MzDWCbO9HCLTO/NtKdwsKUNhBWDpEz5pN4ryU05vRBmGXhySA==}
+  '@nx/nx-win32-arm64-msvc@21.3.5':
+    resolution: {integrity: sha512-lmhzLTVXzQNa0em6v0gBCfswpD5vdgtcjUxr5flR6ylWYo0hVYD4w/EqoymqXq0rU94lx28lksmKX0vhNH5aiw==}
     cpu: [arm64]
     os: [win32]
 
-  '@nx/nx-win32-arm64-msvc@21.2.3':
-    resolution: {integrity: sha512-8Q1ljgFle6F2ZGSe6dLBItSdvYXjO0n2ovZI0zIih9+5OGLdN8wf6iONQJT7he2YST1dowIDPNWdeKiuOzPo6w==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@nx/nx-win32-x64-msvc@21.2.1':
-    resolution: {integrity: sha512-XO0KFzyM2IkBhsvevLJMw8JDSOeWjCEkdxm5q9PJoNAmAuq2fJmwXs/d/KyEr8lohxQzNxt4ZDfUiW9AcSiFOw==}
+  '@nx/nx-win32-x64-msvc@21.3.5':
+    resolution: {integrity: sha512-8ljAlmV96WUK7NbXCL96HDxP7Qm6MDKgz/8mD4XtMJIWvZ098VDv4+1Ce2lK366grQRmNQfYVUuhwPppnJfqug==}
     cpu: [x64]
     os: [win32]
 
-  '@nx/nx-win32-x64-msvc@21.2.3':
-    resolution: {integrity: sha512-qJpHIZU/D48+EZ2bH02/LIFIkANYryGbcbNQUqC+pYA8ZPCU0wMqZVn4UcNMoI9K4YtXe/SvSBdjiObDuRb8yw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@nx/workspace@21.2.3':
-    resolution: {integrity: sha512-bC3J6pgXvL9JWyYmP7AOGCIZhtI6vmY1YLan1T+FFkSr7yyKvIwnnL9E68whQD5jcbJl1Mvu9l0lVlsVdQYF/g==}
+  '@nx/workspace@21.3.5':
+    resolution: {integrity: sha512-jvA/wVOzMANHIvyz+9ACkK/twUaYHWgzDbES+xnQDdNMnjzkbgHPWdeTnjkyu2dspTm4c5nVMHH6ErMv6IjWeQ==}
 
   '@oozcitak/dom@1.15.10':
     resolution: {integrity: sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==}
@@ -1476,8 +1435,8 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@sinclair/typebox@0.27.8':
-    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+  '@sinclair/typebox@0.34.38':
+    resolution: {integrity: sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==}
 
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
@@ -2026,8 +1985,8 @@ packages:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
 
-  axios@1.10.0:
-    resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
+  axios@1.11.0:
+    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -2470,10 +2429,6 @@ packages:
 
   diff-match-patch@1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
-
-  diff-sequences@29.6.3:
-    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -2931,8 +2886,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.3:
-    resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   formdata-polyfill@4.0.10:
@@ -3485,13 +3440,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  jest-diff@29.7.0:
-    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  jest-get-type@29.6.3:
-    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  jest-diff@30.0.5:
+    resolution: {integrity: sha512-1UIqE9PoEKaHcIKvq2vbibrCog4Y8G0zmOxgQUVEiTqwR5hJVMCoDsN1vFvI5JvwD37hjueZ1C4l2FyGnfpE0A==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
@@ -4096,20 +4047,8 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  nx@21.2.1:
-    resolution: {integrity: sha512-wwLa9BSb/wH2KI6CrM356DerDxf8hnzqXx/OvXuKgWsPtOciUdULisJEzdCvehZYg/l2RH84jOLmMVq7OWNuaw==}
-    hasBin: true
-    peerDependencies:
-      '@swc-node/register': ^1.8.0
-      '@swc/core': ^1.3.85
-    peerDependenciesMeta:
-      '@swc-node/register':
-        optional: true
-      '@swc/core':
-        optional: true
-
-  nx@21.2.3:
-    resolution: {integrity: sha512-2wL/2fSmIbRWn6zXaQ/g3kj5DfEaTw/aJkPr6ozJh8BUq5iYKE+tS9oh0PjsVVwN6Pybe80Lu+mn9RgWyeV3xw==}
+  nx@21.3.5:
+    resolution: {integrity: sha512-iRAO7D7SkjhIM6y5xH8GO+ojTJB2QSIzG2xNBgbRwuTV6AxLBkq6sU5hFA0wNzD/LncUeEoJmRtHfbGXfQQORQ==}
     hasBin: true
     peerDependencies:
       '@swc-node/register': ^1.8.0
@@ -4406,9 +4345,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
-  pretty-format@29.7.0:
-    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  pretty-format@30.0.5:
+    resolution: {integrity: sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   pretty-ms@9.2.0:
     resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
@@ -6080,16 +6019,16 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.1
       chalk: 5.4.1
 
-  '@emnapi/core@1.4.4':
+  '@emnapi/core@1.4.5':
     dependencies:
-      '@emnapi/wasi-threads': 1.0.3
+      '@emnapi/wasi-threads': 1.0.4
       tslib: 2.8.1
 
-  '@emnapi/runtime@1.4.4':
+  '@emnapi/runtime@1.4.5':
     dependencies:
       tslib: 2.8.1
 
-  '@emnapi/wasi-threads@1.0.3':
+  '@emnapi/wasi-threads@1.0.4':
     dependencies:
       tslib: 2.8.1
 
@@ -6484,9 +6423,13 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@jest/schemas@29.6.3':
+  '@jest/diff-sequences@30.0.1': {}
+
+  '@jest/get-type@30.0.1': {}
+
+  '@jest/schemas@30.0.5':
     dependencies:
-      '@sinclair/typebox': 0.27.8
+      '@sinclair/typebox': 0.34.38
 
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
@@ -6633,8 +6576,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
-      '@emnapi/core': 1.4.4
-      '@emnapi/runtime': 1.4.4
+      '@emnapi/core': 1.4.5
+      '@emnapi/runtime': 1.4.5
       '@tybys/wasm-util': 0.9.0
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6649,85 +6592,55 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nx/devkit@21.2.3(nx@21.2.3(@swc/core@1.13.1))':
+  '@nx/devkit@21.3.5(nx@21.3.5(@swc/core@1.13.1))':
     dependencies:
       ejs: 3.1.10
       enquirer: 2.3.6
       ignore: 5.3.2
       minimatch: 9.0.3
-      nx: 21.2.3(@swc/core@1.13.1)
+      nx: 21.3.5(@swc/core@1.13.1)
       semver: 7.7.2
       tmp: 0.2.3
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/nx-darwin-arm64@21.2.1':
+  '@nx/nx-darwin-arm64@21.3.5':
     optional: true
 
-  '@nx/nx-darwin-arm64@21.2.3':
+  '@nx/nx-darwin-x64@21.3.5':
     optional: true
 
-  '@nx/nx-darwin-x64@21.2.1':
+  '@nx/nx-freebsd-x64@21.3.5':
     optional: true
 
-  '@nx/nx-darwin-x64@21.2.3':
+  '@nx/nx-linux-arm-gnueabihf@21.3.5':
     optional: true
 
-  '@nx/nx-freebsd-x64@21.2.1':
+  '@nx/nx-linux-arm64-gnu@21.3.5':
     optional: true
 
-  '@nx/nx-freebsd-x64@21.2.3':
+  '@nx/nx-linux-arm64-musl@21.3.5':
     optional: true
 
-  '@nx/nx-linux-arm-gnueabihf@21.2.1':
+  '@nx/nx-linux-x64-gnu@21.3.5':
     optional: true
 
-  '@nx/nx-linux-arm-gnueabihf@21.2.3':
+  '@nx/nx-linux-x64-musl@21.3.5':
     optional: true
 
-  '@nx/nx-linux-arm64-gnu@21.2.1':
+  '@nx/nx-win32-arm64-msvc@21.3.5':
     optional: true
 
-  '@nx/nx-linux-arm64-gnu@21.2.3':
+  '@nx/nx-win32-x64-msvc@21.3.5':
     optional: true
 
-  '@nx/nx-linux-arm64-musl@21.2.1':
-    optional: true
-
-  '@nx/nx-linux-arm64-musl@21.2.3':
-    optional: true
-
-  '@nx/nx-linux-x64-gnu@21.2.1':
-    optional: true
-
-  '@nx/nx-linux-x64-gnu@21.2.3':
-    optional: true
-
-  '@nx/nx-linux-x64-musl@21.2.1':
-    optional: true
-
-  '@nx/nx-linux-x64-musl@21.2.3':
-    optional: true
-
-  '@nx/nx-win32-arm64-msvc@21.2.1':
-    optional: true
-
-  '@nx/nx-win32-arm64-msvc@21.2.3':
-    optional: true
-
-  '@nx/nx-win32-x64-msvc@21.2.1':
-    optional: true
-
-  '@nx/nx-win32-x64-msvc@21.2.3':
-    optional: true
-
-  '@nx/workspace@21.2.3(@swc/core@1.13.1)':
+  '@nx/workspace@21.3.5(@swc/core@1.13.1)':
     dependencies:
-      '@nx/devkit': 21.2.3(nx@21.2.3(@swc/core@1.13.1))
+      '@nx/devkit': 21.3.5(nx@21.3.5(@swc/core@1.13.1))
       '@zkochan/js-yaml': 0.0.7
       chalk: 4.1.2
       enquirer: 2.3.6
-      nx: 21.2.3(@swc/core@1.13.1)
+      nx: 21.3.5(@swc/core@1.13.1)
       picomatch: 4.0.2
       tslib: 2.8.1
       yargs-parser: 21.1.1
@@ -6853,7 +6766,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@sinclair/typebox@0.27.8': {}
+  '@sinclair/typebox@0.34.38': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
@@ -7088,7 +7001,7 @@ snapshots:
   '@types/node-fetch@2.6.12':
     dependencies:
       '@types/node': 22.16.3
-      form-data: 4.0.3
+      form-data: 4.0.4
 
   '@types/node@12.20.55': {}
 
@@ -7527,10 +7440,10 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axios@1.10.0:
+  axios@1.11.0:
     dependencies:
       follow-redirects: 1.15.9
-      form-data: 4.0.3
+      form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -8008,8 +7921,6 @@ snapshots:
       dequal: 2.0.3
 
   diff-match-patch@1.0.5: {}
-
-  diff-sequences@29.6.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -8553,7 +8464,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.3:
+  form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -9199,14 +9110,12 @@ snapshots:
       filelist: 1.0.4
       minimatch: 3.1.2
 
-  jest-diff@29.7.0:
+  jest-diff@30.0.5:
     dependencies:
+      '@jest/diff-sequences': 30.0.1
+      '@jest/get-type': 30.0.1
       chalk: 4.1.2
-      diff-sequences: 29.6.3
-      jest-get-type: 29.6.3
-      pretty-format: 29.7.0
-
-  jest-get-type@29.6.3: {}
+      pretty-format: 30.0.5
 
   jiti@2.4.2: {}
 
@@ -10115,13 +10024,13 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nx@21.2.1(@swc/core@1.13.1):
+  nx@21.3.5(@swc/core@1.13.1):
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.2
       '@zkochan/js-yaml': 0.0.7
-      axios: 1.10.0
+      axios: 1.11.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
@@ -10133,7 +10042,7 @@ snapshots:
       flat: 5.0.2
       front-matter: 4.0.2
       ignore: 5.3.2
-      jest-diff: 29.7.0
+      jest-diff: 30.0.5
       jsonc-parser: 3.2.0
       lines-and-columns: 2.0.3
       minimatch: 9.0.3
@@ -10153,68 +10062,16 @@ snapshots:
       yargs: 17.7.2
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@nx/nx-darwin-arm64': 21.2.1
-      '@nx/nx-darwin-x64': 21.2.1
-      '@nx/nx-freebsd-x64': 21.2.1
-      '@nx/nx-linux-arm-gnueabihf': 21.2.1
-      '@nx/nx-linux-arm64-gnu': 21.2.1
-      '@nx/nx-linux-arm64-musl': 21.2.1
-      '@nx/nx-linux-x64-gnu': 21.2.1
-      '@nx/nx-linux-x64-musl': 21.2.1
-      '@nx/nx-win32-arm64-msvc': 21.2.1
-      '@nx/nx-win32-x64-msvc': 21.2.1
-      '@swc/core': 1.13.1
-    transitivePeerDependencies:
-      - debug
-
-  nx@21.2.3(@swc/core@1.13.1):
-    dependencies:
-      '@napi-rs/wasm-runtime': 0.2.4
-      '@yarnpkg/lockfile': 1.1.0
-      '@yarnpkg/parsers': 3.0.2
-      '@zkochan/js-yaml': 0.0.7
-      axios: 1.10.0
-      chalk: 4.1.2
-      cli-cursor: 3.1.0
-      cli-spinners: 2.6.1
-      cliui: 8.0.1
-      dotenv: 16.4.7
-      dotenv-expand: 11.0.7
-      enquirer: 2.3.6
-      figures: 3.2.0
-      flat: 5.0.2
-      front-matter: 4.0.2
-      ignore: 5.3.2
-      jest-diff: 29.7.0
-      jsonc-parser: 3.2.0
-      lines-and-columns: 2.0.3
-      minimatch: 9.0.3
-      node-machine-id: 1.1.12
-      npm-run-path: 4.0.1
-      open: 8.4.2
-      ora: 5.3.0
-      resolve.exports: 2.0.3
-      semver: 7.7.2
-      string-width: 4.2.3
-      tar-stream: 2.2.0
-      tmp: 0.2.3
-      tree-kill: 1.2.2
-      tsconfig-paths: 4.2.0
-      tslib: 2.8.1
-      yaml: 2.8.0
-      yargs: 17.7.2
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@nx/nx-darwin-arm64': 21.2.3
-      '@nx/nx-darwin-x64': 21.2.3
-      '@nx/nx-freebsd-x64': 21.2.3
-      '@nx/nx-linux-arm-gnueabihf': 21.2.3
-      '@nx/nx-linux-arm64-gnu': 21.2.3
-      '@nx/nx-linux-arm64-musl': 21.2.3
-      '@nx/nx-linux-x64-gnu': 21.2.3
-      '@nx/nx-linux-x64-musl': 21.2.3
-      '@nx/nx-win32-arm64-msvc': 21.2.3
-      '@nx/nx-win32-x64-msvc': 21.2.3
+      '@nx/nx-darwin-arm64': 21.3.5
+      '@nx/nx-darwin-x64': 21.3.5
+      '@nx/nx-freebsd-x64': 21.3.5
+      '@nx/nx-linux-arm-gnueabihf': 21.3.5
+      '@nx/nx-linux-arm64-gnu': 21.3.5
+      '@nx/nx-linux-arm64-musl': 21.3.5
+      '@nx/nx-linux-x64-gnu': 21.3.5
+      '@nx/nx-linux-x64-musl': 21.3.5
+      '@nx/nx-win32-arm64-msvc': 21.3.5
+      '@nx/nx-win32-x64-msvc': 21.3.5
       '@swc/core': 1.13.1
     transitivePeerDependencies:
       - debug
@@ -10513,9 +10370,9 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  pretty-format@29.7.0:
+  pretty-format@30.0.5:
     dependencies:
-      '@jest/schemas': 29.6.3
+      '@jest/schemas': 30.0.5
       ansi-styles: 5.2.0
       react-is: 18.3.1
 


### PR DESCRIPTION
## Summary

- Implement token-based rate limiting to track and control AI usage per user
- Add request-based rate limiting to prevent abuse
- Surface usage information in all API responses for transparency

## Changes

### Backend
- Added `rate-limiter-flexible` for dual rate limiting (tokens + requests)
- Created user rate limit plugin with configurable limits via environment variables
- Enhanced chat endpoint to track token consumption and include usage info in responses
- Added comprehensive property tests for rate limiting behavior

### SDK
- Updated SDK to handle 429 rate limit errors with automatic retry (exponential backoff with jitter)
- Added `ChatResponse` type to include usage information alongside content
- **BREAKING CHANGE**: `chatSync` now returns `ChatResponse` object instead of plain string

### React SDK
- Enhanced `useChat` hook to expose usage information
- Updated `ChatWidget` to display token usage with visual progress bars
- Added rate limit error handling with clear user feedback

### Documentation & Examples
- Updated all READMEs with rate limiting sections
- Enhanced examples to demonstrate usage tracking
- Added clear guidance on handling rate limit errors

## Testing

- ✅ All 571 tests passing
- ✅ Mutation testing: 87.46% score (exceeds 85% threshold)
- ✅ Property tests validate rate limiter behavior under all conditions
- ✅ Integration tests verify complete user flows with rate limiting

## Screenshots

### Usage Display in React SDK
The updated ChatWidget now shows real-time token usage:
- Token count with limit
- Visual progress bar
- Reset time information

### Rate Limit Error Handling
Clear feedback when limits are exceeded with retry guidance.

## Deployment Notes

New environment variables (with defaults):
- `TOKEN_LIMIT_MAX` (default: 100000)
- `TOKEN_LIMIT_TIME_WINDOW` (default: 3600000 ms = 1 hour)
- `REQUEST_LIMIT_MAX` (default: 100)
- `REQUEST_LIMIT_TIME_WINDOW` (default: 3600000 ms = 1 hour)

## Breaking Changes

- `chatSync()` in SDK now returns `{ content: string, usage?: UsageInfo }` instead of just string
- Consumers need to access `.content` property for the AI response

## Related

- Closes MAR-164
- Addresses token tracking requirements for AI usage monitoring

🤖 Generated with Claude Code