### PR TITLE
feat(claude): update create-ticket command to recommend analyze-ticket workflow - Part 2 (MAR-168)

### DIFF
--- a/.claude/commands/create-ticket.md
+++ b/.claude/commands/create-ticket.md
@@ -242,8 +242,8 @@ After successful creation:
 
 1. **Show ticket URL**: "✅ Created ticket: [MAR-XXX: Title](https://linear.app/markwatson/issue/MAR-XXX)"
 2. **Suggest next steps**:
-   - "Ready to start work? Use `/start-ticket MAR-XXX`"
-   - "Need to analyze further? Use `/analyze-ticket MAR-XXX`"
+   - "Ready to analyze the ticket? Use `/analyze-ticket MAR-XXX`" (recommended)
+   - "Want to jump straight to implementation? Use `/start-ticket MAR-XXX`"
    - "Want to add more context? I can help add comments"
 3. **Confirm project assignment**: "Ticket created in Airbolt MVP project"
 


### PR DESCRIPTION
## Summary
- Updated `/create-ticket` command to recommend `/analyze-ticket` as the primary next step
- Encourages proper ticket analysis before jumping into implementation
- Aligns with project's emphasis on thoughtful development

## Testing
This is a documentation-only change to test the PR review workflow. 

**Note**: Previous PR #75 was closed due to GitHub Action permission issues. This is Part 2 of the testing with a cleaner branch name.

## GitHub Action Issues Found
The Claude Code Review GitHub Action failed on PR #75 with:
- Error: "User does not have write access on this repository"
- OIDC token exchange failing
- May need custom GitHub token or proper app permissions

## Linear Ticket
Testing PR review workflow: MAR-168

## Purpose
This PR is specifically created to test the new PR review commands and GitHub Action workflow with a minimal, legitimate change.

## Checklist
- [x] Documentation-only change
- [x] Improves developer workflow
- [x] Commit follows conventional format
- [x] Change is minimal and focused
- [x] Pre-push validation passes