### PR TITLE
docs: update release process documentation and add beta installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ After deployment, Render will show your API URL (e.g., `https://my-ai-backend.on
 Then add to your app:
 
 ```bash
+# Latest stable version
 npm install @airbolt/react-sdk
+
+# Beta version (latest features)
+npm install @airbolt/react-sdk@beta
 ```
 
 ```tsx

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,19 +2,56 @@
 
 ## How to Release
 
+### Step 1: Update Package Versions
+
 Choose the appropriate version bump based on your changes:
 
-1. **Bug fixes**: `pnpm release:patch` (0.7.0 → 0.7.1)
-2. **New features**: `pnpm release:minor` (0.7.0 → 0.8.0)
-3. **Breaking changes**: `pnpm release:major` (0.7.0 → 1.0.0)
+1. **Bug fixes**: Patch version (0.7.0 → 0.7.1)
+2. **New features**: Minor version (0.7.0 → 0.8.0)
+3. **Breaking changes**: Major version (0.7.0 → 1.0.0)
 
-This will automatically:
+Update the SDK package versions manually:
 
-- Update all package versions
-- Create a git commit with message "chore: release vX.Y.Z"
-- Create a git tag "vX.Y.Z"
-- Push the commit and tag to GitHub
-- Trigger CI workflow to validate and publish to npm
+```bash
+# Navigate to each package and bump version
+cd packages/sdk && npm version minor --no-git-tag-version
+cd ../react-sdk && npm version minor --no-git-tag-version
+
+# Update lockfile
+cd ../.. && pnpm install
+```
+
+### Step 2: Commit and Tag
+
+```bash
+# Commit the version changes
+git add -A
+git commit -m "chore(release): bump SDK versions to X.Y.Z"
+
+# Create the release tag
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+
+# Push the tag (this triggers the release workflow)
+git push origin vX.Y.Z
+```
+
+### Step 3: Create PR for Version Updates
+
+Since the main branch is protected, create a PR to merge the version updates:
+
+```bash
+# Create a new branch from your local changes
+git checkout -b chore/release-vX.Y.Z
+
+# Push the branch
+git push origin chore/release-vX.Y.Z
+
+# Create a PR using GitHub CLI
+gh pr create --title "chore(release): bump SDK versions to X.Y.Z" \
+  --body "Updates package versions after vX.Y.Z release"
+```
+
+**Note**: The release will still work even if the version bump PR hasn't been merged yet, because the tag contains the commit with the updated versions.
 
 ## What Happens in CI
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -100,14 +100,16 @@ pnpm dev
 
 ## Releasing (Maintainers Only)
 
-To release a new version:
+To release a new version, see [RELEASES.md](../RELEASES.md) for the detailed process.
 
-```bash
-pnpm release:minor    # or patch/major
-# This automatically handles everything
-```
+Quick summary:
 
-Releases are validated and published from CI after all quality gates pass.
+1. Update package versions manually
+2. Commit and create a git tag
+3. Push the tag to trigger automated release
+4. Create a PR to merge version updates to main
+
+The GitHub Actions workflow handles validation, npm publishing, and GitHub release creation.
 
 ## Questions?
 

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -7,7 +7,11 @@ Part of **[Airbolt](https://github.com/Airbolt-AI/airbolt)** - A production-read
 **🚀 Streaming by default** - Responses stream in real-time for better UX. Set `streaming={false}` for complete responses.
 
 ```bash
+# Latest stable version
 npm install @airbolt/react-sdk
+
+# Beta version (latest features)
+npm install @airbolt/react-sdk@beta
 ```
 
 **Just want to get started?** See the [main README](../../README.md) for the 3-step quickstart guide.

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airbolt/react-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "React hooks and utilities for the Airbolt API with built-in state management",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -5,7 +5,11 @@
 **🚀 Streaming by default** - Responses stream in real-time for better UX. Use `chatSync()` for non-streaming.
 
 ```bash
+# Latest stable version
 npm install @airbolt/sdk
+
+# Beta version (latest features)
+npm install @airbolt/sdk@beta
 ```
 
 **Looking for React components?** Use [@airbolt/react-sdk](../react-sdk/) instead for the easiest integration.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airbolt/sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Type-safe TypeScript SDK for the Airbolt API with automatic token management",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Summary

This PR updates all documentation to reflect the current release process and adds beta installation instructions for the SDKs.

## Changes

### 📝 Documentation Updates

1. **README.md** - Added beta installation instructions for SDKs
2. **packages/sdk/README.md** - Added beta installation option
3. **packages/react-sdk/README.md** - Added beta installation option
4. **RELEASES.md** - Completely rewrote to document the actual release process:
   - Manual version bumping required
   - Tag-driven releases
   - Branch protection workflow
5. **docs/CONTRIBUTING.md** - Updated release section to reference RELEASES.md

### 🚀 Current Release State

- **Latest stable**: v0.3.0 (on npm `@latest`)
- **Latest beta**: v0.8.0 (on npm `@beta`)

### 📋 Why These Changes?

The release process documentation was outdated. The `pnpm release:*` scripts don't actually bump versions (they only target workspace packages), so the process requires manual version updates. This PR documents the actual workflow that was successfully used for the v0.8.0 release.

## Test Instructions

Documentation only - no code changes to test.