### PR TITLE
feat(claude): restore comprehensive code-review command alongside review-pr (MAR-172)

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,5 +1,117 @@
-This command has been renamed to `/review-pr` to better reflect its focus on reviewing pull requests.
+Ultrathink about what makes an exceptional code review—one that elevates both the code and the developer. Consider technical excellence, business impact, maintainability, and team growth.
 
-Please use `/review-pr` instead - it provides the same comprehensive review functionality with enhanced focus on changed lines and their impact.
+**Review Philosophy**: Champion simplicity over cleverness. The best suggestions reduce code while increasing clarity. Today's elegant abstraction is tomorrow's technical debt.
 
-All existing functionality is preserved in the new command.
+## 0. Gather Context (You're a Fresh Agent!)
+
+Since you're starting fresh, gather comprehensive context:
+
+1. **Get PR Information**:
+
+   ```bash
+   gh pr view --json title,body,state,files,commits,url
+   ```
+
+2. **Read the Linear Ticket**:
+   - Extract ticket ID from PR title/body
+   - Use Linear MCP tools to read full ticket details
+   - Check comments for additional context
+
+3. **Understand the Changes**:
+
+   ```bash
+   git fetch origin
+   git diff origin/main...HEAD --stat
+   ```
+
+   - Review list of changed files
+   - Identify patterns: new features vs modifications
+
+4. **Examine Code Changes**:
+   - Use `git diff` to see actual changes
+   - Read modified files to understand context
+   - Check related files that might be affected
+
+5. **Review Codebase Context**:
+   - Look at existing patterns in similar files
+   - Check architecture docs if available
+   - Understand the project's quality standards
+
+## Quality Gates Verification
+
+Review these explicit quality checks:
+
+- **Mutation Testing**: Verify score meets ≥85% threshold for business logic
+- **Security**: Check for vulnerabilities, exposed secrets, unsafe patterns
+- **Performance**: Assess impact on response times, memory usage
+- **Architecture**: Validate clean dependencies, proper layering
+- **Test Quality**: Ensure tests fail when logic breaks per @TESTING.md (not just coverage theater)
+- **Documentation**: Verify all docs are updated and accurate
+
+## Code Review Focus Areas
+
+Then Ultrathink about the specific context of the open PR:
+
+1. **Implementation Quality**
+   - Does it use minimal code for maximum value?
+   - Are patterns consistent with existing codebase?
+   - Is error handling comprehensive?
+   - Are edge cases properly handled?
+
+2. **Test Quality Assessment**
+   - Follow @TESTING.md pyramid: property (40%) > integration (35%) > unit (20%) > mutation (5%)
+   - Tests catch real production failures, not theoretical bugs
+   - Property tests for complex logic, integration for workflows, unit for pure functions
+   - Avoid coverage theatre - tests should fail when logic breaks
+
+3. **Maintainability**
+   - Will future developers understand this easily?
+   - Are complex sections well-documented?
+   - Is the code DRY without being overly abstract?
+
+4. **Business Impact**
+   - Does it fully address the ticket requirements?
+   - Are there any unintended side effects?
+   - Is the user experience optimal?
+
+5. **Documentation Review**
+   - Are code comments helpful and current?
+   - Is API documentation complete?
+   - Are README/setup guides updated?
+   - Do examples work as shown?
+
+6. **What a Senior Architect Would Notice**
+   - Subtle performance implications
+   - Security vulnerabilities
+   - Architectural debt being introduced
+   - Opportunities for broader improvements
+   - Missing abstractions or over-engineering
+
+## Review Output Format
+
+Provide that level of thoughtful, constructive review:
+
+1. **Summary**: Brief overview of what the PR accomplishes
+2. **Positive Observations**: What's done well (be specific)
+3. **Required Changes**: Must-fix issues blocking merge
+4. **Suggestions**: Optional improvements for consideration
+5. **Questions**: Clarifications needed for understanding
+
+Format your review to be:
+
+- **Constructive**: Focus on teaching, not just critiquing
+- **Specific**: Reference exact files and line numbers
+- **Actionable**: Provide clear guidance on fixes
+- **Balanced**: Acknowledge good decisions alongside improvements
+
+## Posting Your Review
+
+**IMPORTANT**: After completing your review, always post it directly to the GitHub PR using one of these methods:
+
+1. **For Approval**: `gh pr review [PR-NUMBER] --approve --body "YOUR REVIEW"`
+2. **For Comments**: `gh pr comment [PR-NUMBER] --body "YOUR REVIEW"`
+3. **For Request Changes**: `gh pr review [PR-NUMBER] --request-changes --body "YOUR REVIEW"`
+
+Note: If reviewing your own PR, use `gh pr comment` instead of review commands.
+
+Remember: A great review elevates both the code and the developer, and should always be posted to the actual PR for visibility and discussion.


### PR DESCRIPTION
## Summary
- Restored the comprehensive `/code-review` command from commit f4b89c1
- Kept the new `/review-pr` command intact for comparison
- Both commands now available to compare effectiveness

## Testing
- No code changes, only Claude command documentation
- Verified both command files exist and have correct content
- No impact on application functionality

## Linear Ticket
Closes MAR-172

## Context
The new `/review-pr` command focuses strictly on changed lines, but we found it may be lacking compared to the original comprehensive approach. This PR restores the old version while keeping the new one, allowing us to:
- Use the comprehensive review approach immediately
- Compare effectiveness of both approaches
- Eventually merge the best aspects of both

## Checklist
- [x] All CI checks pass for my changes (pre-existing failures unrelated)
- [x] Documentation accurate - no updates needed
- [x] No breaking changes
- [x] Clean git history with meaningful commit message