### PR TITLE
Add multiple Render deployment buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@
 
 ## Getting Started
 
-**Deploy the Airbolt backend**
+### Deploy to Render
 
-Deploy our production-ready LLM proxy to Render. You'll get your own private API that securely handles LLM calls:
+**Option 1: Deploy Latest Stable Release (Recommended)**  
+Deploy our production-tested version:
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Airbolt-AI/airbolt&branch=v0.8.0)
 
+**Option 2: Deploy Latest Development**  
+Deploy the latest features from main branch (may include unreleased changes):
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Airbolt-AI/airbolt)
 
 **What this deploys:**


### PR DESCRIPTION
## Summary
- offer two Render buttons for stable and latest deployments
- update stable button to v0.8.0

## Testing
- `pnpm ai:quick` *(fails: nx run-many not found)*
- `pnpm ai:check` *(fails to complete)*


------
https://chatgpt.com/codex/tasks/task_e_688918270b18832aac5a1778d8693d6f